### PR TITLE
Add jitpack.io dependency repo to README gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,11 @@ fun main(args: Array<String>) {
 
 ## Gradle
 ```gradle
+repositories {
+    // Needed to resolve unreleased dependencies of com.github.almasb:fxgl:0.2.9
+    maven { url 'https://jitpack.io' }
+}
+
 dependencies {
     compile 'com.github.almasb:fxgl:0.2.9'
 }


### PR DESCRIPTION
```
repositories {
    // Needed to resolve unreleased dependencies of com.github.almasb:fxgl:0.2.9
    maven { url 'https://jitpack.io' }
}
```

Without this, the dependencies (`com.github.AlmasB:*`) of `fxgl` are not resolved.