### PR TITLE
Issue#386 (HitBox - generate name automatically if not provided)

### DIFF
--- a/fxgl/src/main/java/com/almasb/fxgl/physics/HitBox.java
+++ b/fxgl/src/main/java/com/almasb/fxgl/physics/HitBox.java
@@ -39,6 +39,17 @@ public final class HitBox implements Serializable {
     private Bounds bounds;
 
     /**
+     * Creates a hit box with the given shape.
+     * The name of the {@code {@link HitBox}} will be auto generated
+     * based upon the {@code hashCode} of the given {@code {@link BoundingShape}}.
+     *
+     * @param shape bounding shape
+     */
+    public HitBox(BoundingShape shape) {
+        this(String.valueOf(shape.hashCode()), shape);
+    }
+
+    /**
      * Creates a hit box with given name and shape.
      * Local origin is set to default (0, 0).
      *

--- a/fxgl/src/main/java/com/almasb/fxgl/physics/HitBox.java
+++ b/fxgl/src/main/java/com/almasb/fxgl/physics/HitBox.java
@@ -50,6 +50,18 @@ public final class HitBox implements Serializable {
     }
 
     /**
+     * Creates a hit box with the given local origin and shape.
+     * The name of the {@code {@link HitBox}} will be auto generated
+     * based upon the {@code hashCode} of the given {@code {@link BoundingShape}}.
+     *
+     * @param localOrigin origin of hit box
+     * @param shape bounding shape
+     */
+    public HitBox(Point2D localOrigin, BoundingShape shape){
+        this(String.valueOf(shape.hashCode()), localOrigin, shape);
+    }
+
+    /**
      * Creates a hit box with given name and shape.
      * Local origin is set to default (0, 0).
      *


### PR DESCRIPTION
Hey again :)

The name of a HitBox is now optional and will be auto generated (hashCode of the given BoundingShape) if using the new overloaded constructor.