### PR TITLE
Improve Java module names

### DIFF
--- a/fxgl-achievement/src/main/java/module-info.java
+++ b/fxgl-achievement/src/main/java/module-info.java
@@ -1,10 +1,10 @@
 /**
  * @author Almas Baimagambetov (almaslvl@gmail.com)
  */
-module fxgl.achievement {
-    requires fxgl.core;
+module com.almasb.fxgl.achievement {
+    requires com.almasb.fxgl.core;
 
     exports com.almasb.fxgl.achievement;
 
-    opens com.almasb.fxgl.achievement to fxgl.core;
+    opens com.almasb.fxgl.achievement to com.almasb.fxgl.core;
 }

--- a/fxgl-animation/src/main/java/module-info.java
+++ b/fxgl-animation/src/main/java/module-info.java
@@ -1,8 +1,8 @@
 /**
  *
  */
-module fxgl.animation {
-    requires fxgl.core;
+module com.almasb.fxgl.animation {
+    requires com.almasb.fxgl.core;
 
     exports com.almasb.fxgl.animation;
 }

--- a/fxgl-core/src/main/java/module-info.java
+++ b/fxgl-core/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 /**
  *
  */
-module fxgl.core {
+module com.almasb.fxgl.core {
     requires transitive kotlin.stdlib;
     requires transitive javafx.graphics;
     requires transitive javafx.base;

--- a/fxgl-effects/src/main/java/module-info.java
+++ b/fxgl-effects/src/main/java/module-info.java
@@ -1,11 +1,11 @@
 /**
  * @author Almas Baimagambetov (almaslvl@gmail.com)
  */
-module fxgl.effects {
-    requires fxgl.core;
-    requires fxgl.animation;
-    requires fxgl.entity;
-    requires fxgl.media;
+module com.almasb.fxgl.effects {
+    requires com.almasb.fxgl.core;
+    requires com.almasb.fxgl.animation;
+    requires com.almasb.fxgl.entity;
+    requires com.almasb.fxgl.media;
 
     exports com.almasb.fxgl.particle;
 }

--- a/fxgl-entity/src/main/java/module-info.java
+++ b/fxgl-entity/src/main/java/module-info.java
@@ -1,12 +1,12 @@
 /**
  * @author Almas Baimagambetov (almaslvl@gmail.com)
  */
-module fxgl.entity {
-    requires fxgl.core;
+module com.almasb.fxgl.entity {
+    requires com.almasb.fxgl.core;
     requires java.xml;
 
-    opens com.almasb.fxgl.entity.component to fxgl.core;
-    opens com.almasb.fxgl.entity.components to fxgl.core;
+    opens com.almasb.fxgl.entity.component to com.almasb.fxgl.core;
+    opens com.almasb.fxgl.entity.components to com.almasb.fxgl.core;
 
     exports com.almasb.fxgl.entity;
     exports com.almasb.fxgl.entity.component;

--- a/fxgl-events/src/main/java/module-info.java
+++ b/fxgl-events/src/main/java/module-info.java
@@ -1,8 +1,8 @@
 /**
  *
  */
-module fxgl.events {
-    requires fxgl.core;
+module com.almasb.fxgl.events {
+    requires com.almasb.fxgl.core;
 
     exports com.almasb.fxgl.event;
 }

--- a/fxgl-input/src/main/java/module-info.java
+++ b/fxgl-input/src/main/java/module-info.java
@@ -1,8 +1,8 @@
 /**
  * @author Almas Baimagambetov (almaslvl@gmail.com)
  */
-module fxgl.input {
-    requires fxgl.core;
+module com.almasb.fxgl.input {
+    requires com.almasb.fxgl.core;
 
     exports com.almasb.fxgl.input;
     exports com.almasb.fxgl.input.view;

--- a/fxgl-io/src/main/java/module-info.java
+++ b/fxgl-io/src/main/java/module-info.java
@@ -1,8 +1,8 @@
 /**
  *
  */
-module fxgl.io {
-    requires fxgl.core;
+module com.almasb.fxgl.io {
+    requires com.almasb.fxgl.core;
 
     exports com.almasb.fxgl.io;
 }

--- a/fxgl-media/src/main/java/module-info.java
+++ b/fxgl-media/src/main/java/module-info.java
@@ -1,12 +1,12 @@
 /**
  * @author Almas Baimagambetov (almaslvl@gmail.com)
  */
-module fxgl.media {
-    requires fxgl.core;
+module com.almasb.fxgl.media {
+    requires com.almasb.fxgl.core;
     requires javafx.media;
 
     exports com.almasb.fxgl.audio;
     exports com.almasb.fxgl.texture;
 
-    exports com.almasb.fxgl.audio.impl to fxgl.all;
+    exports com.almasb.fxgl.audio.impl to com.almasb.fxgl.all;
 }

--- a/fxgl-notification/src/main/java/module-info.java
+++ b/fxgl-notification/src/main/java/module-info.java
@@ -1,14 +1,14 @@
 /**
  * @author Almas Baimagambetov (almaslvl@gmail.com)
  */
-module fxgl.notification {
-    requires fxgl.core;
-    requires fxgl.animation;
-    requires fxgl.time;
+module com.almasb.fxgl.notification {
+    requires com.almasb.fxgl.core;
+    requires com.almasb.fxgl.animation;
+    requires com.almasb.fxgl.time;
 
     exports com.almasb.fxgl.notification;
     exports com.almasb.fxgl.notification.view;
 
-    exports com.almasb.fxgl.notification.impl to fxgl.all;
-    opens com.almasb.fxgl.notification.impl to fxgl.core;
+    exports com.almasb.fxgl.notification.impl to com.almasb.fxgl.all;
+    opens com.almasb.fxgl.notification.impl to com.almasb.fxgl.core;
 }

--- a/fxgl-samples/src/main/java/module-info.java
+++ b/fxgl-samples/src/main/java/module-info.java
@@ -1,4 +1,4 @@
 open module samples.main {
     requires kotlin.stdlib;
-    requires fxgl.all;
+    requires com.almasb.fxgl.all;
 }

--- a/fxgl-test/src/main/java/module-info.java
+++ b/fxgl-test/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 /**
  * @author Almas Baimagambetov (almaslvl@gmail.com)
  */
-module fxgl.test {
+module com.almasb.fxgl.test {
     requires javafx.graphics;
     requires org.junit.jupiter.api;
 

--- a/fxgl-time/src/main/java/module-info.java
+++ b/fxgl-time/src/main/java/module-info.java
@@ -1,8 +1,8 @@
 /**
  *
  */
-module fxgl.time {
-    requires fxgl.core;
+module com.almasb.fxgl.time {
+    requires com.almasb.fxgl.core;
 
     exports com.almasb.fxgl.time;
 }

--- a/fxgl-ui/src/main/java/module-info.java
+++ b/fxgl-ui/src/main/java/module-info.java
@@ -1,9 +1,9 @@
 /**
  *
  */
-module fxgl.ui {
-    requires fxgl.core;
-    requires fxgl.animation;
+module com.almasb.fxgl.ui {
+    requires com.almasb.fxgl.core;
+    requires com.almasb.fxgl.animation;
 
     requires javafx.controls;
 

--- a/fxgl/src/main/java/module-info.java
+++ b/fxgl/src/main/java/module-info.java
@@ -1,19 +1,19 @@
 /**
  * @author Almas Baimagambetov (almaslvl@gmail.com)
  */
-module fxgl.all {
-    requires transitive fxgl.core;
-    requires transitive fxgl.achievement;
-    requires transitive fxgl.animation;
-    requires transitive fxgl.effects;
-    requires transitive fxgl.entity;
-    requires transitive fxgl.events;
-    requires transitive fxgl.input;
-    requires transitive fxgl.io;
-    requires transitive fxgl.media;
-    requires transitive fxgl.notification;
-    requires transitive fxgl.time;
-    requires transitive fxgl.ui;
+module com.almasb.fxgl.all {
+    requires transitive com.almasb.fxgl.core;
+    requires transitive com.almasb.fxgl.achievement;
+    requires transitive com.almasb.fxgl.animation;
+    requires transitive com.almasb.fxgl.effects;
+    requires transitive com.almasb.fxgl.entity;
+    requires transitive com.almasb.fxgl.events;
+    requires transitive com.almasb.fxgl.input;
+    requires transitive com.almasb.fxgl.io;
+    requires transitive com.almasb.fxgl.media;
+    requires transitive com.almasb.fxgl.notification;
+    requires transitive com.almasb.fxgl.time;
+    requires transitive com.almasb.fxgl.ui;
 
     requires transitive javafx.base;
     requires transitive javafx.graphics;
@@ -21,8 +21,8 @@ module fxgl.all {
     requires transitive javafx.fxml;
     requires transitive javafx.swing;
 
-    opens com.almasb.fxgl.dsl to fxgl.core;
-    opens com.almasb.fxgl.dev to fxgl.core;
+    opens com.almasb.fxgl.dsl to com.almasb.fxgl.core;
+    opens com.almasb.fxgl.dev to com.almasb.fxgl.core;
 
     exports com.almasb.fxgl.app;
     exports com.almasb.fxgl.dev;


### PR DESCRIPTION
Improve Java module names by pre-pending `com.almasb.` to all modules declared by FXGL.

Samples and 3rd-party applications that make use of FXGL module names need to be updated.

Closes #621