### PR TITLE
add Entity.getComponent() extension method which uses type inference

### DIFF
--- a/fxgl-entity/src/main/kotlin/com/almasb/fxgl/entity/EntityExt.kt
+++ b/fxgl-entity/src/main/kotlin/com/almasb/fxgl/entity/EntityExt.kt
@@ -1,0 +1,16 @@
+/*
+ * FXGL - JavaFX Game Library. The MIT License (MIT).
+ * Copyright (c) AlmasB (almaslvl@gmail.com).
+ * See LICENSE for details.
+ */
+
+package com.almasb.fxgl.entity
+
+import com.almasb.fxgl.entity.component.Component
+
+/**
+ * @return component of given type or throws exception if entity has no such component
+ */
+inline fun <reified T : Component> Entity.getComponent(): T {
+    return this.getComponent(T::class.java)
+}

--- a/fxgl-entity/src/test/kotlin/com/almasb/fxgl/entity/EntityExtTest.kt
+++ b/fxgl-entity/src/test/kotlin/com/almasb/fxgl/entity/EntityExtTest.kt
@@ -1,0 +1,27 @@
+package com.almasb.fxgl.entity
+
+import com.almasb.fxgl.entity.component.Component
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.hamcrest.CoreMatchers.*
+import org.hamcrest.MatcherAssert.assertThat
+
+internal class EntityExtTest {
+    private lateinit var entity: Entity
+
+    @BeforeEach
+    fun setUp() {
+        entity = Entity()
+    }
+
+    @Test
+    fun `Get component with extension`() {
+        val comp = TestComponent()
+        entity.addComponent(comp)
+
+        val actual : TestComponent = entity.getComponent()
+        assertThat(actual, `is`(comp))
+    }
+
+    private inner class TestComponent : Component()
+}


### PR DESCRIPTION
add Entity.getComponent() extension method which uses type inference instead of a class parameter