### PR TITLE
Make TMX level parser more robust by removing whitespace.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ target/
 
 # IntelliJ IDEA
 .idea/
+.run/
 out/
 *.iml
 

--- a/fxgl-entity/src/main/kotlin/com/almasb/fxgl/entity/level/tiled/TMXLevelLoader.kt
+++ b/fxgl-entity/src/main/kotlin/com/almasb/fxgl/entity/level/tiled/TMXLevelLoader.kt
@@ -303,7 +303,7 @@ class TMXLevelLoader : LevelLoader {
     private fun parseData(layer: Layer, data: String, start: StartElement) {
         when (start.getString("encoding")) {
             "csv" -> {
-                layer.data = data.replace("\n", "").split(",").map { it.toInt() }
+                layer.data = data.replace("\n", "").split(",").map { it.trim().toInt() }
             }
 
             "base64" -> {

--- a/fxgl-entity/src/test/kotlin/com/almasb/fxgl/entity/level/tiled/TMXLevelLoaderTest.kt
+++ b/fxgl-entity/src/test/kotlin/com/almasb/fxgl/entity/level/tiled/TMXLevelLoaderTest.kt
@@ -45,12 +45,13 @@ class TMXLevelLoaderTest {
         assertThat(level.entities.size, `is`(4 + 2))
     }
 
-    @Test
-    fun `Load tmx level with gid objects`() {
+    @ParameterizedTest
+    @CsvSource("map_with_gid_objects.tmx", "map_with_indented_csv_data.tmx")
+    fun `Load tmx level with gid objects`(mapName: String) {
         val world = GameWorld()
         world.addEntityFactory(MyEntityFactory())
 
-        val level = TMXLevelLoader().load(javaClass.getResource("map_with_gid_objects.tmx"), world)
+        val level = TMXLevelLoader().load(javaClass.getResource(mapName), world)
 
         assertThat(level.width, `is`(16*10))
         assertThat(level.height, `is`(16*10))

--- a/fxgl-entity/src/test/resources/com/almasb/fxgl/entity/level/tiled/map_with_indented_csv_data.tmx
+++ b/fxgl-entity/src/test/resources/com/almasb/fxgl/entity/level/tiled/map_with_indented_csv_data.tmx
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.2" tiledversion="1.2.3" orientation="orthogonal" renderorder="right-down" width="10" height="10"
+     tilewidth="16" tileheight="16" infinite="0" nextlayerid="3" nextobjectid="34">
+    <properties>
+        <property name="testInt" type="int" value="33"/>
+    </properties>
+    <tileset firstgid="1" name="comic_sans_tileset_black" tilewidth="16" tileheight="16" tilecount="256" columns="16">
+        <image source="tileset_black.png" width="256" height="256"/>
+    </tileset>
+    <layer id="1" name="Tile layer 1" width="10" height="10">
+        <data encoding="csv">
+            220,220,220,220,220,220,220,220,220,220,
+            220,0,0,0,0,0,0,0,0,220,
+            220,0,0,0,0,0,0,0,0,220,
+            220,0,0,0,0,0,0,0,0,220,
+            220,0,0,0,0,0,0,0,0,220,
+            220,0,0,0,0,0,0,0,0,220,
+            220,0,0,0,0,0,0,0,0,220,
+            220,0,0,0,0,0,0,0,0,220,
+            220,0,0,0,0,0,0,0,0,220,
+            220,220,220,220,220,220,220,220,220,220
+        </data>
+    </layer>
+    <objectgroup id="2" name="Object layer 1">
+        <object id="14" type="Wall" x="0" y="144" width="144" height="16"/>
+        <object id="15" type="Wall" x="0" y="0" width="16" height="144"/>
+        <object id="17" type="Wall" x="144" y="16" width="16" height="144"/>
+        <object id="18" type="Wall" x="16" y="0" width="144" height="16"/>
+        <object id="28" type="Player" gid="11" x="47.9178" y="80" width="16" height="16"/>
+        <object id="31" type="Coin" gid="84" x="111.625" y="128" width="16" height="16"/>
+        <object id="33" type="Coin" gid="84" x="32.25" y="47" width="16" height="16"/>
+    </objectgroup>
+</map>


### PR DESCRIPTION
I propose to make the TMX level parser more robust by trimming strings before converting them to integers in parseData. Someone might do what I did, edit the TMX file by hand and let IntelliJ format it...