### PR TITLE
#711 Add scaleOrigin and rotationOrigin to AnimationBuilder

### DIFF
--- a/fxgl-animation/src/main/kotlin/com/almasb/fxgl/animation/Animatable.kt
+++ b/fxgl-animation/src/main/kotlin/com/almasb/fxgl/animation/Animatable.kt
@@ -7,6 +7,7 @@
 package com.almasb.fxgl.animation
 
 import javafx.beans.property.DoubleProperty
+import javafx.geometry.Point2D
 
 /**
  * An object whose position, scale, rotation and opacity can be animated.
@@ -24,4 +25,7 @@ interface Animatable {
     fun rotationProperty(): DoubleProperty
 
     fun opacityProperty(): DoubleProperty
+
+    fun setScaleOrigin(pivotPoint: Point2D)
+    fun setRotationOrigin(pivotPoint: Point2D)
 }

--- a/fxgl-animation/src/test/kotlin/com/almasb/fxgl/animation/AnimationBuilderTest.kt
+++ b/fxgl-animation/src/test/kotlin/com/almasb/fxgl/animation/AnimationBuilderTest.kt
@@ -3,7 +3,7 @@
  * Copyright (c) AlmasB (almaslvl@gmail.com).
  * See LICENSE for details.
  */
-
+@file:Suppress("JAVA_MODULE_DOES_NOT_DEPEND_ON_MODULE")
 package com.almasb.fxgl.animation
 
 import com.almasb.fxgl.entity.Entity

--- a/fxgl-samples/src/main/kotlin/sandbox/anim/ScaleAndRotateSample.kt
+++ b/fxgl-samples/src/main/kotlin/sandbox/anim/ScaleAndRotateSample.kt
@@ -1,0 +1,106 @@
+/*
+ * FXGL - JavaFX Game Library. The MIT License (MIT).
+ * Copyright (c) AlmasB (almaslvl@gmail.com).
+ * See LICENSE for details.
+ */
+
+package sandbox.anim
+
+import com.almasb.fxgl.animation.Interpolators
+import com.almasb.fxgl.app.GameApplication
+import com.almasb.fxgl.app.GameSettings
+import com.almasb.fxgl.dsl.FXGL.Companion.addUINode
+import com.almasb.fxgl.dsl.FXGL.Companion.animationBuilder
+import com.almasb.fxgl.dsl.FXGL.Companion.getGameScene
+import com.almasb.fxgl.dsl.FXGL.Companion.onKeyDown
+import javafx.geometry.Point2D
+import javafx.scene.input.KeyCode
+import javafx.scene.paint.Color
+import javafx.scene.shape.Rectangle
+import javafx.util.Duration
+import java.util.HashMap
+
+class ScaleAndRotateSample : GameApplication() {
+
+    private val animations = HashMap<Int, Runnable>()
+    private var animationSelector = 0
+
+
+    override fun initSettings(settings: GameSettings) {
+        settings.width = 800
+        settings.height = 600
+        settings.title = "Rotation and scale sample"
+    }
+
+    override fun initInput() {
+        onKeyDown(KeyCode.F, Runnable {
+            animations[animationSelector++]?.run()
+            animationSelector %= animations.size
+        })
+    }
+
+    override fun initGame() {
+        getGameScene().setBackgroundColor(Color.BLACK)
+
+        val rect = Rectangle(400.0, 100.0, Color.WHITE)
+
+        addUINode(rect, 200.0, 250.0)
+
+        animations[0] = Runnable {
+            animationBuilder()
+                    .duration(Duration.seconds(2.0))
+                    .interpolator(Interpolators.LINEAR.EASE_IN_OUT())
+                    .repeat(2)
+                    .autoReverse(true)
+                    .rotate(rect)
+                    .origin(Point2D(0.0, 0.0))
+                    .from(0.0)
+                    .to(360.0)
+                    .buildAndPlay()
+        }
+
+        animations[1] = Runnable {
+            animationBuilder()
+                    .duration(Duration.seconds(2.0))
+                    .interpolator(Interpolators.LINEAR.EASE_IN_OUT())
+                    .repeat(2)
+                    .autoReverse(true)
+                    .scale(rect)
+                    .origin(Point2D(0.0, 0.0))
+                    .from(Point2D(1.0, 1.0))
+                    .to(Point2D(2.0,2.0))
+                    .buildAndPlay()
+        }
+
+        animations[2] = Runnable {
+            animationBuilder()
+                    .duration(Duration.seconds(2.0))
+                    .interpolator(Interpolators.LINEAR.EASE_IN_OUT())
+                    .repeat(2)
+                    .autoReverse(true)
+                    .rotate(rect)
+                    .from(0.0)
+                    .to(360.0)
+                    .buildAndPlay()
+        }
+
+        animations[3] = Runnable {
+            animationBuilder()
+                    .duration(Duration.seconds(2.0))
+                    .interpolator(Interpolators.LINEAR.EASE_IN_OUT())
+                    .repeat(2)
+                    .autoReverse(true)
+                    .scale(rect)
+                    .from(Point2D(1.0, 1.0))
+                    .to(Point2D(2.0,2.0))
+                    .buildAndPlay()
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        fun main(args: Array<String>) {
+            launch(ScaleAndRotateSample::class.java, args)
+        }
+    }
+}


### PR DESCRIPTION
Add origin points to rotate and scale animations.

Add sample in Kotlin to show how it works and difference between animations with and without origins.

closes #711 