### PR TITLE
#660 InjectInTest::inject use names provided by the @Inject() annotation to inject values

### DIFF
--- a/fxgl-achievement/src/test/kotlin/com/almasb/fxgl/achievement/AchievementServiceTest.kt
+++ b/fxgl-achievement/src/test/kotlin/com/almasb/fxgl/achievement/AchievementServiceTest.kt
@@ -3,7 +3,7 @@
  * Copyright (c) AlmasB (almaslvl@gmail.com).
  * See LICENSE for details.
  */
-
+@file:Suppress("JAVA_MODULE_DOES_NOT_DEPEND_ON_MODULE")
 package com.almasb.fxgl.achievement
 
 import com.almasb.fxgl.core.collection.PropertyMap
@@ -39,9 +39,11 @@ class AchievementServiceTest {
     fun setUp() {
         achievementManager = AchievementService()
         val lookup = MethodHandles.lookup()
+        val injectMap = mapOf(
+                "achievementsFromSettings" to listOf(a2),
+                "eventBusService" to  EventBusService())
 
-        inject(lookup, achievementManager, "achievementsFromSettings", listOf(a2))
-        inject(lookup, achievementManager, "eventBusService",  EventBusService())
+        inject(lookup, achievementManager, injectMap)
     }
 
     @Test
@@ -63,9 +65,9 @@ class AchievementServiceTest {
 
     @Test
     fun `Fail if achievement not found`() {
-        assertThrows(IllegalArgumentException::class.java, {
+        assertThrows(IllegalArgumentException::class.java) {
             achievementManager.getAchievementByName("NoSuchAchievement")
-        })
+        }
     }
 
     @Test
@@ -167,6 +169,7 @@ class AchievementServiceTest {
     }
 
     companion object {
+        @Suppress("UNUSED")
         @JvmStatic fun varValueProvider(): Stream<Arguments> {
             return Stream.of(
                     arguments(2, 1, 0),

--- a/fxgl-io/src/test/kotlin/com/almasb/fxgl/io/FileSystemServiceTest.kt
+++ b/fxgl-io/src/test/kotlin/com/almasb/fxgl/io/FileSystemServiceTest.kt
@@ -1,15 +1,17 @@
+@file:Suppress("JAVA_MODULE_DOES_NOT_DEPEND_ON_MODULE")
 package com.almasb.fxgl.io
 
 import com.almasb.fxgl.test.InjectInTest
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder
-import org.junit.jupiter.api.*
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
-import java.lang.RuntimeException
 import java.lang.invoke.MethodHandles
-import java.nio.file.Files
 import java.nio.file.Files.*
 import java.nio.file.Paths.get as path
 
@@ -21,6 +23,7 @@ class FileSystemServiceTest {
     companion object {
         private lateinit var fs: FileSystemService
 
+        @Suppress("UNUSED")
         @BeforeAll
         @JvmStatic fun before() {
             cleanUp()
@@ -39,9 +42,11 @@ class FileSystemServiceTest {
             assertTrue(exists(path("testdir/testfile.json")), "test file is not present before")
 
             fs = FileSystemService()
+            val injectMap = mapOf(
+                    "isDesktop" to true,
+                    "isFileSystemWriteAllowed" to true)
 
-            InjectInTest.inject(MethodHandles.lookup(), fs, "isDesktop", true)
-            InjectInTest.inject(MethodHandles.lookup(), fs, "isFileSystemWriteAllowed", true)
+            InjectInTest.inject(MethodHandles.lookup(), fs, injectMap)
 
             fs.onInit()
         }
@@ -118,7 +123,7 @@ class FileSystemServiceTest {
 
         assertTrue(exists(path("somefile.txt")))
 
-        assertThat(Files.readAllLines(path("somefile.txt")), `is`(text))
+        assertThat(readAllLines(path("somefile.txt")), `is`(text))
     }
 
     @Test
@@ -225,9 +230,11 @@ class FileSystemServiceTest {
     @Test
     fun `Fail on mobile if no private storage present`() {
         val f = FileSystemService()
+        val injectMap = mapOf(
+                "isDesktop" to false,
+                "isFileSystemWriteAllowed" to true)
 
-        InjectInTest.inject(MethodHandles.lookup(), f, "isDesktop", false)
-        InjectInTest.inject(MethodHandles.lookup(), f, "isFileSystemWriteAllowed", true)
+        InjectInTest.inject(MethodHandles.lookup(), f, injectMap)
 
         assertThrows<RuntimeException> {
             f.onInit()
@@ -237,9 +244,11 @@ class FileSystemServiceTest {
     @Test
     fun `FS is not changed if FS write is not allowed`() {
         val f = FileSystemService()
+        val injectMap = mapOf(
+                "isDesktop" to true,
+                "isFileSystemWriteAllowed" to false)
 
-        InjectInTest.inject(MethodHandles.lookup(), f, "isDesktop", true)
-        InjectInTest.inject(MethodHandles.lookup(), f, "isFileSystemWriteAllowed", false)
+        InjectInTest.inject(MethodHandles.lookup(), f, injectMap)
 
         val text = listOf("Test Line1", "Test Line2")
 

--- a/fxgl-notification/src/test/kotlin/com/almasb/fxgl/notification/NotificationServiceTest.kt
+++ b/fxgl-notification/src/test/kotlin/com/almasb/fxgl/notification/NotificationServiceTest.kt
@@ -3,7 +3,7 @@
  * Copyright (c) AlmasB (almaslvl@gmail.com).
  * See LICENSE for details.
  */
-
+@file:Suppress("JAVA_MODULE_DOES_NOT_DEPEND_ON_MODULE")
 package com.almasb.fxgl.notification
 
 import com.almasb.fxgl.input.Input
@@ -61,9 +61,11 @@ class NotificationServiceTest {
         val provider = NotificationServiceProvider()
 
         val lookup = MethodHandles.lookup()
+        val injectMap = mapOf(
+                "sceneService" to sceneService,
+                "notificationViewClass" to XboxNotificationView::class.java)
 
-        InjectInTest.inject(lookup, provider, "sceneService", sceneService)
-        InjectInTest.inject(lookup, provider, "notificationViewClass", XboxNotificationView::class.java)
+        InjectInTest.inject(lookup, provider, injectMap)
 
         notificationService = provider
     }

--- a/fxgl-test/src/main/java/com/almasb/fxgl/test/InjectInTest.java
+++ b/fxgl-test/src/main/java/com/almasb/fxgl/test/InjectInTest.java
@@ -9,11 +9,14 @@ package com.almasb.fxgl.test;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.lang.reflect.Field;
+import java.util.Map;
 
 /**
  * @author Almas Baimagambetov (almaslvl@gmail.com)
  */
 public class InjectInTest {
+
+    private InjectInTest() {}
 
     /**
      * @param lookup the lookup created by the module where class of instance lives
@@ -32,5 +35,16 @@ public class InjectInTest {
         } catch (Exception e) {
             throw new IllegalArgumentException(e);
         }
+    }
+
+    /**
+     * Convenience method to mass inject multiple values
+     * @param lookup the lookup created by the module where class of instance lives
+     * @param instance object to inject to
+     * @param fieldsMap Map of field names of instances and values to inject
+     */
+    public static void inject(MethodHandles.Lookup lookup, Object instance, Map<String, Object> fieldsMap) {
+        fieldsMap
+                .forEach((key, value) -> inject(lookup, instance, key, value));
     }
 }

--- a/fxgl/src/test/kotlin/com/almasb/fxgl/services/UpdaterServiceTest.kt
+++ b/fxgl/src/test/kotlin/com/almasb/fxgl/services/UpdaterServiceTest.kt
@@ -3,15 +3,15 @@
  * Copyright (c) AlmasB (almaslvl@gmail.com).
  * See LICENSE for details.
  */
-
+@file:Suppress("JAVA_MODULE_DOES_NOT_DEPEND_ON_MODULE")
 package com.almasb.fxgl.services
 
 import com.almasb.fxgl.app.ApplicationMode
 import com.almasb.fxgl.app.services.UpdaterService
 import com.almasb.fxgl.net.NetService
 import com.almasb.fxgl.test.InjectInTest
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
@@ -30,10 +30,12 @@ class UpdaterServiceTest {
         updater = UpdaterService()
 
         val lookup = MethodHandles.lookup()
+        val injectMap = mapOf(
+                "appMode" to ApplicationMode.RELEASE,
+                "urlPOM" to "https://raw.githubusercontent.com/AlmasB/FXGL/master/pom.xml",
+                "netService" to NetService())
 
-        InjectInTest.inject(lookup, updater, "appMode", ApplicationMode.RELEASE)
-        InjectInTest.inject(lookup, updater, "urlPOM", "https://raw.githubusercontent.com/AlmasB/FXGL/master/pom.xml")
-        InjectInTest.inject(lookup, updater, "netService", NetService())
+        InjectInTest.inject(lookup, updater, injectMap)
     }
 
     @Test


### PR DESCRIPTION
Add convenience inject method to InjectInTest which receives Map of parameters to inject;

Replace multiple injects in tests with new method;

closes #660