### PR TITLE
Add pause callbacks to EngineService

### DIFF
--- a/fxgl-core/src/main/kotlin/com/almasb/fxgl/core/EngineService.kt
+++ b/fxgl-core/src/main/kotlin/com/almasb/fxgl/core/EngineService.kt
@@ -53,12 +53,12 @@ abstract class EngineService : Updatable, SerializableType {
     open fun onExit() { }
 
     /**
-     * Called just before the main loop is paused, which is only happens when the main window is minimized.
+     * Called just before the main loop is paused.
      */
     open fun onMainLoopPausing() { }
 
     /**
-     * Called just after the main loop is resumed, which is only happens when the minimized main window is opened.
+     * Called just after the main loop is resumed.
      */
     open fun onMainLoopResumed() { }
 

--- a/fxgl-core/src/main/kotlin/com/almasb/fxgl/core/EngineService.kt
+++ b/fxgl-core/src/main/kotlin/com/almasb/fxgl/core/EngineService.kt
@@ -38,12 +38,12 @@ abstract class EngineService : Updatable, SerializableType {
     open fun onGameReady(vars: PropertyMap) { }
 
     /**
-     * This is called on a JavaFX thread at each engine tick in any scene.
+     * Called on a JavaFX thread at each engine tick in any scene.
      */
     override fun onUpdate(tpf: Double) { }
 
     /**
-     * This is called on a JavaFX thread at each engine tick _only_ in game scene.
+     * Called on a JavaFX thread at each engine tick _only_ in game scene.
      */
     open fun onGameUpdate(tpf: Double) { }
 
@@ -51,6 +51,16 @@ abstract class EngineService : Updatable, SerializableType {
      * Called just before the engine exits and the application shuts down.
      */
     open fun onExit() { }
+
+    /**
+     * Called just before the main loop is paused, which is only happens when the main window is minimized.
+     */
+    open fun onMainLoopPausing() { }
+
+    /**
+     * Called just after the main loop is resumed, which is only happens when the minimized main window is opened.
+     */
+    open fun onMainLoopResumed() { }
 
     override fun write(bundle: Bundle) { }
 

--- a/fxgl-core/src/test/kotlin/com/almasb/fxgl/core/EngineServiceTest.kt
+++ b/fxgl-core/src/test/kotlin/com/almasb/fxgl/core/EngineServiceTest.kt
@@ -3,7 +3,7 @@
  * Copyright (c) AlmasB (almaslvl@gmail.com).
  * See LICENSE for details.
  */
-
+@file:Suppress("JAVA_MODULE_DOES_NOT_DEPEND_ON_MODULE")
 package com.almasb.fxgl.core
 
 import com.almasb.fxgl.core.collection.PropertyMap
@@ -25,6 +25,8 @@ class EngineServiceTest {
         engine.onGameReady(PropertyMap())
         engine.onUpdate(1.0)
         engine.onGameUpdate(1.0)
+        engine.onMainLoopPausing()
+        engine.onMainLoopResumed()
         engine.onExit()
         engine.write(Bundle("test"))
         engine.read(Bundle("test"))

--- a/fxgl/src/main/kotlin/com/almasb/fxgl/app/Engine.kt
+++ b/fxgl/src/main/kotlin/com/almasb/fxgl/app/Engine.kt
@@ -162,11 +162,15 @@ internal class Engine(val settings: ReadOnlyGameSettings) {
     }
 
     fun pauseLoop() {
+        services.forEach { it.onMainLoopPausing() }
+
         loop.pause()
     }
 
     fun resumeLoop() {
         loop.resume()
+
+        services.forEach { it.onMainLoopResumed() }
     }
 
     fun write(bundle: Bundle) {


### PR DESCRIPTION
Resolves #879

Should resolve the mentioned issue. I tested it manually and it worked. Of course those pause functions are only called when the window is minimized.

Not sure there is anything to test. It would make sense to me to add tests in the implementing class once those functions are used. Otherwise let me know.