### PR TITLE
Added positionOriginZ to TransformComponent

### DIFF
--- a/fxgl-entity/src/main/kotlin/com/almasb/fxgl/entity/components/TransformComponent.kt
+++ b/fxgl-entity/src/main/kotlin/com/almasb/fxgl/entity/components/TransformComponent.kt
@@ -41,7 +41,7 @@ class TransformComponent(x: Double, y: Double, angle: Double, scaleX: Double, sc
 
     private val propPositionOriginX = SimpleDoubleProperty(0.0)
     private val propPositionOriginY = SimpleDoubleProperty(0.0)
-	private val propPositionOriginZ = SimpleDoubleProperty(0.0)
+    private val propPositionOriginZ = SimpleDoubleProperty(0.0)
 
     private val propScaleOriginX = SimpleDoubleProperty(0.0)
     private val propScaleOriginY = SimpleDoubleProperty(0.0)
@@ -133,7 +133,7 @@ class TransformComponent(x: Double, y: Double, angle: Double, scaleX: Double, sc
 
     fun positionOriginXProperty() = propPositionOriginX
     fun positionOriginYProperty() = propPositionOriginY
-	fun positionOriginZProperty() = propPositionOriginZ
+    fun positionOriginZProperty() = propPositionOriginZ
 
     fun scaleOriginXProperty() = propScaleOriginX
     fun scaleOriginYProperty() = propScaleOriginY

--- a/fxgl-entity/src/main/kotlin/com/almasb/fxgl/entity/components/TransformComponent.kt
+++ b/fxgl-entity/src/main/kotlin/com/almasb/fxgl/entity/components/TransformComponent.kt
@@ -41,6 +41,7 @@ class TransformComponent(x: Double, y: Double, angle: Double, scaleX: Double, sc
 
     private val propPositionOriginX = SimpleDoubleProperty(0.0)
     private val propPositionOriginY = SimpleDoubleProperty(0.0)
+	private val propPositionOriginZ = SimpleDoubleProperty(0.0)
 
     private val propScaleOriginX = SimpleDoubleProperty(0.0)
     private val propScaleOriginY = SimpleDoubleProperty(0.0)
@@ -132,6 +133,7 @@ class TransformComponent(x: Double, y: Double, angle: Double, scaleX: Double, sc
 
     fun positionOriginXProperty() = propPositionOriginX
     fun positionOriginYProperty() = propPositionOriginY
+	fun positionOriginZProperty() = propPositionOriginZ
 
     fun scaleOriginXProperty() = propScaleOriginX
     fun scaleOriginYProperty() = propScaleOriginY

--- a/fxgl-entity/src/main/kotlin/com/almasb/fxgl/entity/components/ViewComponent.kt
+++ b/fxgl-entity/src/main/kotlin/com/almasb/fxgl/entity/components/ViewComponent.kt
@@ -83,7 +83,7 @@ class ViewComponent : Component() {
     override fun onAdded() {
         viewRoot.translateXProperty().bind(entity.xProperty().subtract(entity.transformComponent.positionOriginXProperty()))
         viewRoot.translateYProperty().bind(entity.yProperty().subtract(entity.transformComponent.positionOriginYProperty()))
-	viewRoot.translateZProperty().bind(entity.zProperty().subtract(entity.transformComponent.positionOriginZProperty()))
+        viewRoot.translateZProperty().bind(entity.zProperty().subtract(entity.transformComponent.positionOriginZProperty()))
 
         viewRootNoTransform.translateXProperty().bind(viewRoot.translateXProperty())
         viewRootNoTransform.translateYProperty().bind(viewRoot.translateYProperty())

--- a/fxgl-entity/src/main/kotlin/com/almasb/fxgl/entity/components/ViewComponent.kt
+++ b/fxgl-entity/src/main/kotlin/com/almasb/fxgl/entity/components/ViewComponent.kt
@@ -83,7 +83,7 @@ class ViewComponent : Component() {
     override fun onAdded() {
         viewRoot.translateXProperty().bind(entity.xProperty().subtract(entity.transformComponent.positionOriginXProperty()))
         viewRoot.translateYProperty().bind(entity.yProperty().subtract(entity.transformComponent.positionOriginYProperty()))
-		viewRoot.translateZProperty().bind(entity.zProperty().subtract(entity.transformComponent.positionOriginZProperty()))
+	viewRoot.translateZProperty().bind(entity.zProperty().subtract(entity.transformComponent.positionOriginZProperty()))
 
         viewRootNoTransform.translateXProperty().bind(viewRoot.translateXProperty())
         viewRootNoTransform.translateYProperty().bind(viewRoot.translateYProperty())

--- a/fxgl-entity/src/main/kotlin/com/almasb/fxgl/entity/components/ViewComponent.kt
+++ b/fxgl-entity/src/main/kotlin/com/almasb/fxgl/entity/components/ViewComponent.kt
@@ -83,8 +83,7 @@ class ViewComponent : Component() {
     override fun onAdded() {
         viewRoot.translateXProperty().bind(entity.xProperty().subtract(entity.transformComponent.positionOriginXProperty()))
         viewRoot.translateYProperty().bind(entity.yProperty().subtract(entity.transformComponent.positionOriginYProperty()))
-
-        viewRoot.translateZProperty().bind(entity.transformComponent.zProperty())
+		viewRoot.translateZProperty().bind(entity.zProperty().subtract(entity.transformComponent.positionOriginZProperty()))
 
         viewRootNoTransform.translateXProperty().bind(viewRoot.translateXProperty())
         viewRootNoTransform.translateYProperty().bind(viewRoot.translateYProperty())


### PR DESCRIPTION
From class ViewComponent:
    Changed:
    `viewRoot.translateZProperty().bind(entity.transformComponent.zProperty())`
    To:
    `viewRoot.translateZProperty().bind(entity.yProperty().subtract(entity.transformComponent.positionOriginZProperty()))`

From class TransformComponent:
  And added the necessary variable and function in order to work correctly:
  `private val propPositionOriginZ = SimpleDoubleProperty(0.0)`
  `fun positionOriginZProperty() = propPositionOriginZ`

Run some basic tests using the supplied 3D examples under fxgl-samples / ... / sandbox/test3d and everything seemed to be fine.
