### PR TITLE
Created functionality for specifying inventory maximum stack size

### DIFF
--- a/fxgl-samples/src/main/java/sandbox/InventorySample.java
+++ b/fxgl-samples/src/main/java/sandbox/InventorySample.java
@@ -87,7 +87,6 @@ public class InventorySample extends GameApplication {
 
     @Override
     protected void initGame() {
-
         // Add initial items in player inventory
         inventorySubScene.playerInventory.add(woodEntity, "Wood", "Wood description", inventorySubScene.view, 15);
         inventorySubScene.playerInventory.add(stoneEntity, "Stone", "Stone description", inventorySubScene.view, 10);
@@ -95,7 +94,6 @@ public class InventorySample extends GameApplication {
     }
 
     public void pickupItem(Entity item, String name, String description, int quantity) {
-
         if (getip(name.toLowerCase()).get() > 0) {
             inventorySubScene.playerInventory.add(item, name, description, inventorySubScene.view, quantity);
             inc(name.toLowerCase(), -1);
@@ -114,6 +112,7 @@ public class InventorySample extends GameApplication {
 
 
         public InventorySubScene() {
+            playerInventory.setRemoveItemsIfQty0(true);
 
             getContentRoot().getChildren().addAll(view);
             getContentRoot().setTranslateX(300);
@@ -129,12 +128,8 @@ public class InventorySample extends GameApplication {
                 var selectedItem = (Entity) view.getListView().getSelectionModel().getSelectedItem();
 
                 if (selectedItem != null) {
-                    var itemData = inventorySubScene.playerInventory.getData((Entity) selectedItem).get();
-                    if (itemData.getQuantity() > 1) {
-                        itemData.setQuantity(itemData.getQuantity() - 1);
-                    } else {
-                        playerInventory.remove(selectedItem);
-                    }
+                    var item = inventorySubScene.playerInventory.getData((Entity) selectedItem).get().get(0).getUserItem();
+                    playerInventory.incrementQuantity(item, -1);
                 }
                 view.getListView().refresh();
             });
@@ -150,9 +145,8 @@ public class InventorySample extends GameApplication {
                 var selectedItem = (Entity) view.getListView().getSelectionModel().getSelectedItem();
 
                 if (selectedItem != null) {
-                    var itemData = inventorySubScene.playerInventory.getData((Entity) selectedItem).get();
-                    itemData.setQuantity(0);
-                    playerInventory.remove(selectedItem);
+                    var itemData = inventorySubScene.playerInventory.getData((Entity) selectedItem).get().get(0).getUserItem();
+                    playerInventory.removeItem(selectedItem);
                 }
                 view.getListView().refresh();
             });

--- a/fxgl-samples/src/main/java/sandbox/InventorySample.java
+++ b/fxgl-samples/src/main/java/sandbox/InventorySample.java
@@ -128,7 +128,7 @@ public class InventorySample extends GameApplication {
                 var selectedItem = (Entity) view.getListView().getSelectionModel().getSelectedItem();
 
                 if (selectedItem != null) {
-                    var item = inventorySubScene.playerInventory.getData((Entity) selectedItem).get().get(0).getUserItem();
+                    var item = inventorySubScene.playerInventory.getData((Entity) selectedItem).get(0).getUserItem();
                     playerInventory.incrementQuantity(item, -1);
                 }
                 view.getListView().refresh();
@@ -145,8 +145,8 @@ public class InventorySample extends GameApplication {
                 var selectedItem = (Entity) view.getListView().getSelectionModel().getSelectedItem();
 
                 if (selectedItem != null) {
-                    var itemData = inventorySubScene.playerInventory.getData((Entity) selectedItem).get().get(0).getUserItem();
-                    playerInventory.removeItem(selectedItem);
+                    var itemData = inventorySubScene.playerInventory.getData((Entity) selectedItem).get(0).getUserItem();
+                    playerInventory.remove(selectedItem);
                 }
                 view.getListView().refresh();
             });

--- a/fxgl-trade/src/main/kotlin/com/almasb/fxgl/inventory/Inventory.kt
+++ b/fxgl-trade/src/main/kotlin/com/almasb/fxgl/inventory/Inventory.kt
@@ -19,6 +19,7 @@ import javafx.scene.Node
  * Represents an inventory (bag) of user-defined items.
  *
  * @author Almas Baimagambetov (almaslvl@gmail.com)
+ * @author Adam Bocco (adam.bocco@gmail.com)
  */
 class Inventory<T>(var capacity: Int) {
 

--- a/fxgl-trade/src/main/kotlin/com/almasb/fxgl/inventory/Inventory.kt
+++ b/fxgl-trade/src/main/kotlin/com/almasb/fxgl/inventory/Inventory.kt
@@ -65,10 +65,12 @@ class Inventory<T>(var capacity: Int) {
     fun setStackMax(newStackMax: Int): Boolean {
         if (newStackMax >= stackMax) {
             stackMax = newStackMax
+            return true
         }
         for (item in allData.values) {
             for (stack in item) {
-                if (stack.quantity > newStackMax) return false
+                if (stack.quantity > newStackMax)
+                    return false
             }
         }
         stackMax = newStackMax
@@ -195,7 +197,6 @@ class Inventory<T>(var capacity: Int) {
         if (amount < 0 && itemQuantity + amount < 0)
             return false
 
-
         quantityCount = amount
 
         /**
@@ -215,7 +216,6 @@ class Inventory<T>(var capacity: Int) {
                     quantityCount += stack.quantity
 
                     stack.quantity = 0
-
                 }
 
                 if (isRemoveItemsIfQty0 && stack.quantity == 0) {
@@ -244,7 +244,6 @@ class Inventory<T>(var capacity: Int) {
                     quantityCount -= stackMax - stack.quantity
 
                     stack.quantity = stackMax
-
                 }
             }
             // Create new item stacks until amount has been added

--- a/fxgl-trade/src/main/kotlin/com/almasb/fxgl/inventory/Inventory.kt
+++ b/fxgl-trade/src/main/kotlin/com/almasb/fxgl/inventory/Inventory.kt
@@ -16,6 +16,7 @@ import javafx.scene.Group
 import javafx.scene.Node
 import java.util.*
 
+
 /**
  * Represents an inventory (bag) of user-defined items.
  *
@@ -28,15 +29,24 @@ class Inventory<T>(var capacity: Int) {
     private val items = FXCollections.observableArrayList<T>()
     private val itemsProperty = FXCollections.unmodifiableObservableList(items)
 
-    private val itemsData = hashMapOf<T, ItemData<T>>()
+    private val itemsData = hashMapOf<T, ObservableList<ItemData<T>>>()
+
+    private var stackMax = Int.MAX_VALUE
 
     /**
      * Number of items in inventory.
      */
     val size: Int
-        get() = items.size
+        get() {
+            var totalSize = 0
+            for (item in items) {
+                totalSize += itemsData[item]?.size!!
+            }
+            return totalSize
+        }
 
-    val allData: Map<T, ItemData<T>>
+
+    val allData: Map<T, ObservableList<ItemData<T>>>
         get() = itemsData.toMap()
 
     val isFull: Boolean
@@ -44,16 +54,38 @@ class Inventory<T>(var capacity: Int) {
 
     var isRemoveItemsIfQty0 = false
 
+    fun getStackMax(): Int {
+        return stackMax
+    }
+
+    /**
+     * @return true if operation was successful
+     * Cannot set stackMax less than item with highest quantity in inventory
+     */
+    fun setStackMax(newStackMax: Int): Boolean {
+        if (newStackMax >= stackMax) {
+            stackMax = newStackMax
+        }
+        for (item in allData.values) {
+            for (stack in item) {
+                if (stack.quantity > newStackMax) return false
+            }
+        }
+        stackMax = newStackMax
+
+        return true
+    }
+
     /**
      * @return read-only list of items
      */
     fun itemsProperty(): ObservableList<T> = itemsProperty
 
     /**
+     * @returns false if inventory is full, if adding quantity creates stacks greater than capacity, or reducing quantity past 0
      * Add [item] to inventory.
      * If [item] (as checked by equals()) is already present, then its quantity is increased by [quantity]
-     * (i.e. the inventory size does not change).
-     * Otherwise the item is added to inventory (the inventory size is increased by 1).
+     * Inventory size may change if adding quantity greater than stackMax
      */
     @JvmOverloads fun add(
             item: T,
@@ -64,39 +96,73 @@ class Inventory<T>(var capacity: Int) {
     ): Boolean {
 
         if (item in items) {
-            getData(item).get().quantity += quantity
-            return true
+            return incrementQuantity(item, quantity)
         }
 
         if (isFull)
             return false
 
-        itemsData[item] = ItemData(item).also {
+        itemsData[item] = FXCollections.observableArrayList()
+
+        itemsData[item]?.add(ItemData(item).also {
             it.name = name
             it.description = description
             it.view = view
-            it.quantity = quantity
-        }
+        })
 
         items += item
 
-        return true
+        if (quantity <= stackMax) {
+            itemsData[item]?.get(0)?.quantity = quantity
+            return true
+        }
+        else {
+            itemsData[item]?.get(0)?.quantity = stackMax
+
+            // If quantity can't fit in one stack, create more
+            if (incrementQuantity(item, quantity-stackMax)) {
+                return true
+            }
+            // If not enough room in inventory, remove initially added item
+            else {
+                removeItem(item)
+                return false
+            }
+
+        }
     }
 
     /**
      * Removes [item] from inventory, reducing the inventory size by 1.
      * If you only want to reduce quantity, use [incrementQuantity] with negative amount instead.
      */
-    fun remove(item: T) {
+    fun removeItem(item: T) {
         items -= item
         itemsData -= item
     }
 
-    fun getData(item: T): Optional<ItemData<T>> {
+    private fun removeStack(itemData: ItemData<T>) {
+        if (itemData.userItem in items)
+            itemsData[itemData.userItem]?.remove(itemData)
+    }
+
+    fun getData(item: T): Optional<ObservableList<ItemData<T>>> {
         if (item !in items)
             return Optional.empty()
 
         return Optional.of(itemsData[item]!!)
+    }
+
+    /**
+     * @return sum quantity of all type [item] in inventory
+     */
+    fun getItemQuantity(item:T): Int {
+        if (item !in items) return 0
+        var totalItemSize = 0
+        for (stack in getData(item).get()) {
+            totalItemSize += stack.quantity
+        }
+        return totalItemSize
     }
 
     /**
@@ -108,17 +174,102 @@ class Inventory<T>(var capacity: Int) {
             return false
         }
 
-        val data = getData(item).get()
+        val stacks = getData(item).get()
 
-        // can't go less than 0
-        if (amount < 0 && data.quantity + amount < 0)
+        // Details used for creating new stacks
+        val itemTemplate = stacks[0]
+
+        // Check if there is room in inventory to add all quantity
+        val freeSpace = capacity - size
+        val itemQuantity = getItemQuantity(item)
+        var quantityCount = amount
+
+        for (stack in stacks) {
+            quantityCount -= stackMax - stack.quantity
+        }
+
+        if (freeSpace < quantityCount.toDouble()/stackMax)
             return false
 
-        data.quantity += amount
+        // can't go less than 0
+        if (amount < 0 && itemQuantity + amount < 0)
+            return false
 
-        if (isRemoveItemsIfQty0 && data.quantity == 0)
-            remove(item)
 
+        quantityCount = amount
+
+        /**
+         * If incrementing with negative numbers, reduce or remove stacks of [item] until [amount] has been subtracted
+         */
+        if (amount < 0) {
+            for (stack in stacks.reversed()) {
+
+                if (quantityCount >= 0) break
+
+                if (quantityCount >= -stack.quantity) {
+                    stack.quantity += quantityCount
+
+                    quantityCount = 0
+                }
+                else {
+                    quantityCount += stack.quantity
+
+                    stack.quantity = 0
+
+                }
+
+                if (isRemoveItemsIfQty0 && stack.quantity == 0) {
+                    removeStack(stack)
+
+                    if (getItemQuantity(item) == 0)
+                        removeItem(item)
+                }
+            }
+        }
+
+        /**
+         * If incrementing with positive numbers, fill non-full stacks first, then create new item stacks
+         */
+        else {
+            for (stack in stacks) {
+
+                if (quantityCount <= stackMax - stack.quantity) {
+                    stack.quantity += quantityCount
+
+                    quantityCount = 0
+
+                    break
+                }
+                else if (stack.quantity < stackMax){
+                    quantityCount -= stackMax - stack.quantity
+
+                    stack.quantity = stackMax
+
+                }
+            }
+            // Create new item stacks until amount has been added
+            while (quantityCount > 0) {
+                var newItemQty: Int
+
+                if (quantityCount < stackMax ) {
+                    newItemQty = quantityCount
+
+                    quantityCount = 0
+                }
+                else {
+                    newItemQty = stackMax
+
+                    quantityCount -= stackMax
+                }
+
+                itemsData[item]?.add(ItemData(item).also {
+                    it.name = itemTemplate.name
+                    it.description = itemTemplate.description
+                    it.view = itemTemplate.view
+                    it.quantity = newItemQty
+                })
+            }
+        }
         return true
     }
 }

--- a/fxgl-trade/src/main/kotlin/com/almasb/fxgl/inventory/view/InventoryListView.kt
+++ b/fxgl-trade/src/main/kotlin/com/almasb/fxgl/inventory/view/InventoryListView.kt
@@ -31,7 +31,7 @@ class InventoryListCell<T>(private val inventory: Inventory<T>) : ListCell<T>() 
             graphic = null
 
         } else {
-            val itemData = inventory.getData(item).get()
+            val itemData = inventory.getData(item)
             val limit = 30
             val name = if (itemData[0].name.length > limit) itemData[0].name.substring(0, limit) + "..." else itemData[0].name
 

--- a/fxgl-trade/src/main/kotlin/com/almasb/fxgl/inventory/view/InventoryListView.kt
+++ b/fxgl-trade/src/main/kotlin/com/almasb/fxgl/inventory/view/InventoryListView.kt
@@ -33,9 +33,9 @@ class InventoryListCell<T>(private val inventory: Inventory<T>) : ListCell<T>() 
         } else {
             val itemData = inventory.getData(item).get()
             val limit = 30
-            val name = if (itemData.name.length > limit) itemData.name.substring(0, limit) + "..." else itemData.name
+            val name = if (itemData[0].name.length > limit) itemData[0].name.substring(0, limit) + "..." else itemData[0].name
 
-            text = "$name - ${itemData.quantity} \n${itemData.description}"
+            text = "$name - ${itemData[0].quantity} \n${itemData[0].description}"
         }
     }
 }

--- a/fxgl-trade/src/main/kotlin/com/almasb/fxgl/inventory/view/InventoryView.kt
+++ b/fxgl-trade/src/main/kotlin/com/almasb/fxgl/inventory/view/InventoryView.kt
@@ -6,7 +6,6 @@
 package com.almasb.fxgl.inventory.view
 
 import com.almasb.fxgl.inventory.Inventory
-import javafx.collections.ObservableList
 import javafx.scene.Parent
 import javafx.scene.layout.VBox
 

--- a/fxgl-trade/src/test/kotlin/com/almasb/fxgl/inventory/InventoryTest.kt
+++ b/fxgl-trade/src/test/kotlin/com/almasb/fxgl/inventory/InventoryTest.kt
@@ -6,6 +6,7 @@
 @file:Suppress("JAVA_MODULE_DOES_NOT_DEPEND_ON_MODULE")
 package com.almasb.fxgl.inventory
 
+import javafx.collections.FXCollections
 import javafx.scene.shape.Rectangle
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
@@ -42,7 +43,7 @@ class InventoryTest {
 
         assertTrue(inventory.isFull)
 
-        inventory.removeItem("100")
+        inventory.remove("100")
 
         assertFalse(inventory.isFull)
     }
@@ -71,7 +72,7 @@ class InventoryTest {
         assertThat(inventory.size, `is`(1))
         assertThat(inventory.getItemQuantity("Hello"), `is`(1))
 
-        inventory.removeItem("Hello")
+        inventory.remove("Hello")
 
         assertThat(inventory.size, `is`(0))
     }
@@ -131,8 +132,8 @@ class InventoryTest {
     }
 
     @Test
-    fun `getData returns empty optional if no item`() {
-        assertFalse(inventory.getData("bla-bla").isPresent)
+    fun `getData returns empty list if no item`() {
+        assertThat(inventory.getData("bla-bla"), `is`(FXCollections.observableArrayList()))
     }
 
     @Test

--- a/fxgl-trade/src/test/kotlin/com/almasb/fxgl/inventory/InventoryTest.kt
+++ b/fxgl-trade/src/test/kotlin/com/almasb/fxgl/inventory/InventoryTest.kt
@@ -42,7 +42,7 @@ class InventoryTest {
 
         assertTrue(inventory.isFull)
 
-        inventory.remove("100")
+        inventory.removeItem("100")
 
         assertFalse(inventory.isFull)
     }
@@ -52,26 +52,26 @@ class InventoryTest {
         inventory.add("Hello")
 
         assertThat(inventory.size, `is`(1))
-        assertThat(inventory.getData("Hello").get().quantity, `is`(1))
+        assertThat(inventory.getItemQuantity("Hello"), `is`(1))
 
         // we are adding the same thing (as defined by equals()), so size remains the same
         // but quantity should change
         inventory.add("Hello")
 
         assertThat(inventory.size, `is`(1))
-        assertThat(inventory.getData("Hello").get().quantity, `is`(2))
+        assertThat(inventory.getItemQuantity("Hello"), `is`(2))
 
         inventory.add("Hello", quantity = 30)
 
         assertThat(inventory.size, `is`(1))
-        assertThat(inventory.getData("Hello").get().quantity, `is`(32))
+        assertThat(inventory.getItemQuantity("Hello"), `is`(32))
 
         inventory.incrementQuantity("Hello", -31)
 
         assertThat(inventory.size, `is`(1))
-        assertThat(inventory.getData("Hello").get().quantity, `is`(1))
+        assertThat(inventory.getItemQuantity("Hello"), `is`(1))
 
-        inventory.remove("Hello")
+        inventory.removeItem("Hello")
 
         assertThat(inventory.size, `is`(0))
     }
@@ -85,8 +85,8 @@ class InventoryTest {
         assertThat(inventory.allData.size, `is`(1))
 
         val itemData = inventory.allData["Hello"]!!
-        assertThat(itemData.userItem, `is`("Hello"))
-        assertThat(itemData.quantity, `is`(1))
+        assertThat(itemData[0].userItem, `is`("Hello"))
+        assertThat(itemData[0].quantity, `is`(1))
 
         val view = Rectangle()
 
@@ -95,16 +95,16 @@ class InventoryTest {
         assertThat(inventory.allData.size, `is`(2))
 
         val itemData2 = inventory.allData["Hi"]!!
-        assertThat(itemData2.userItem, `is`("Hi"))
-        assertThat(itemData2.name, `is`("name"))
-        assertThat(itemData2.description, `is`("description"))
-        assertThat(itemData2.view, `is`(view))
-        assertThat(itemData2.quantity, `is`(3))
+        assertThat(itemData2[0].userItem, `is`("Hi"))
+        assertThat(itemData2[0].name, `is`("name"))
+        assertThat(itemData2[0].description, `is`("description"))
+        assertThat(itemData2[0].view, `is`(view))
+        assertThat(itemData2[0].quantity, `is`(3))
 
-        assertThat(itemData2.nameProperty().value, `is`("name"))
-        assertThat(itemData2.descriptionProperty().value, `is`("description"))
-        assertThat(itemData2.viewProperty().value, `is`(view))
-        assertThat(itemData2.quantityProperty().value, `is`(3))
+        assertThat(itemData2[0].nameProperty().value, `is`("name"))
+        assertThat(itemData2[0].descriptionProperty().value, `is`("description"))
+        assertThat(itemData2[0].viewProperty().value, `is`(view))
+        assertThat(itemData2[0].quantityProperty().value, `is`(3))
     }
 
     @Test
@@ -125,6 +125,7 @@ class InventoryTest {
 
         // should remove item "Hello" since the flag is on
         inventory.incrementQuantity("Hello", -2)
+
 
         assertThat(inventory.itemsProperty().size, `is`(0))
     }
@@ -153,5 +154,113 @@ class InventoryTest {
         inventory.add("Hello", quantity = 3)
 
         assertFalse(inventory.incrementQuantity("Hello", -5))
+    }
+
+    @Test
+    fun `New items are created when adding quantity of items past stackMax`() {
+        inventory.setStackMax(3)
+
+        inventory.add("Hello", quantity = 7)
+
+        // Should create 3 stacks of quantities: [3, 3, 1]
+        assertThat(inventory.size, `is`(3))
+
+        // Should create 5 stacks of quantities: [3, 3, 3, 3, 2]
+        inventory.add("Hello", quantity = 7)
+
+        assertThat(inventory.size, `is`(5))
+    }
+
+    @Test
+    fun `New items are created when incrementing quantity past stackMax`() {
+        inventory.setStackMax(3)
+
+        inventory.add("Hello", quantity = 3)
+
+        // Should create stacks: [3, 3, 3, 1]
+        inventory.incrementQuantity("Hello", 7)
+
+        assertThat(inventory.size, `is`(4))
+
+        // Should increment stacks: [3, 3, 3, 3, 3]
+        inventory.incrementQuantity("Hello", 5)
+
+        assertThat(inventory.size, `is`(5))
+    }
+
+    @Test
+    fun `getItemQuantity returns total quantity of all item's stacks`() {
+        inventory.setStackMax(3)
+
+        // Stacks should be: [3, 3, 3, 3, 3]
+        inventory.add("Hello", quantity = 15)
+
+        assertThat(inventory.size, `is`(5))
+
+        assertTrue(inventory.incrementQuantity("Hello", -10))
+
+        // Stacks should be: [3, 2, 0, 0, 0]
+        assertThat(inventory.size, `is`(5))
+        assertThat(inventory.getItemQuantity("Hello"), `is`(5))
+
+        //Stacks should be: [3, 3, 3, 3, 3, 1]
+        inventory.incrementQuantity("Hello", 11)
+
+        assertThat(inventory.size, `is`(6))
+        assertThat(inventory.getItemQuantity("Hello"), `is` (16))
+    }
+
+    @Test
+    fun `Stacks are removed when incrementing quantity when isRemoveItemsIfQty0 is true`() {
+        inventory.setStackMax(3)
+
+        // Stacks should be: [3, 3, 3, 3, 3]
+        inventory.add("Hello", quantity = 15)
+
+        inventory.isRemoveItemsIfQty0 = true
+
+        // Stacks should be: [3, 2]
+        assertTrue(inventory.incrementQuantity("Hello", -10))
+
+        assertThat(inventory.size, `is`(2))
+        assertThat(inventory.getItemQuantity("Hello"), `is` (5))
+
+        // Item should be removed entirely
+        assertTrue(inventory.incrementQuantity("Hello", -5))
+
+        assertThat(inventory.size, `is`(0))
+        assertThat(inventory.getItemQuantity("Hello"), `is` (0))
+    }
+
+    @Test
+    fun `Cannot change stackMax to higher than greatest item quantity`() {
+        inventory.setStackMax(5)
+
+        inventory.add("Hello", quantity = 5)
+
+        assertThat(inventory.size, `is`(1))
+
+        assertFalse(inventory.setStackMax(4))
+
+        assertThat(inventory.getStackMax(), `is`(5))
+    }
+
+    @Test
+    fun `Cannot increment quantity past inventory size with specified stackMax`() {
+        inventory = Inventory(5)
+        inventory.setStackMax(3)
+
+        assertFalse(inventory.add("Hello", quantity = 16))
+        assertTrue(inventory.add("Hello", quantity = 15))
+
+        assertTrue(inventory.incrementQuantity("Hello", -5))
+
+        assertFalse(inventory.incrementQuantity("Hello", 6))
+
+        assertThat(inventory.getItemQuantity("Hello"), `is`(10))
+
+        assertFalse(inventory.incrementQuantity("Hello", -11))
+
+        assertTrue(inventory.incrementQuantity("Hello", -10))
     }
 }


### PR DESCRIPTION
@AlmasB 

I have simplified my PR to allow setting `stackMax` using the original design. In addition I have updated the inventory tests, sample, and default list view. In Inventory.kt, everything works the same if no `stackMax` is set. However, the user must index the item they want with `itemData[0]` to grab the first stack. 

In order to accomodate stackMax: 

  - I added a safeguard for setting stackMax if there is an item over that quantity already in inventory.
  - I added `getItemQuantity` to return the total quantity of all stacks of a specific item
  - `add()` and `incrementQuantity()` now dynamically create stacks within the bounds of `capacity`

Another thing to mention is that in order to create new stacks, I have to use some existing item as a template as seen in `incrementQuantity`. This means an item could be added of the same type `T` and have varying names and descriptions. 

Let me know what you think!

Thanks again,
Adam Bocco