### PR TITLE
Get size of EntityGroup

### DIFF
--- a/fxgl-entity/src/main/kotlin/com/almasb/fxgl/entity/EntityGroup.kt
+++ b/fxgl-entity/src/main/kotlin/com/almasb/fxgl/entity/EntityGroup.kt
@@ -38,6 +38,9 @@ class EntityGroup(
             return entities.filter { it.isActive }
         }
 
+    val size: Int
+        get() = entitiesCopy.size
+
     init {
         world.addWorldListener(this)
     }

--- a/fxgl-entity/src/test/kotlin/com/almasb/fxgl/entity/EntityGroupTest.kt
+++ b/fxgl-entity/src/test/kotlin/com/almasb/fxgl/entity/EntityGroupTest.kt
@@ -39,14 +39,11 @@ class EntityGroupTest {
 
         world.addEntity(e)
 
-        var count = 0
-
         group.forEach {
             assertThat(it, `is`(e))
-            count++
         }
 
-        assertThat(count, `is`(1))
+        assertThat(group.size, `is`(1))
     }
 
     @Test
@@ -57,13 +54,7 @@ class EntityGroupTest {
         world.addEntity(e)
         world.removeEntity(e)
 
-        var count = 0
-
-        group.forEach {
-            count++
-        }
-
-        assertThat(count, `is`(0))
+        assertThat(group.size, `is`(0))
     }
 
     @Test
@@ -75,13 +66,7 @@ class EntityGroupTest {
 
         world.addEntity(e)
 
-        var count = 0
-
-        group.forEach {
-            count++
-        }
-
-        assertThat(count, `is`(0))
+        assertThat(group.size, `is`(0))
     }
 
     @Test
@@ -111,23 +96,22 @@ class EntityGroupTest {
 
         world.addEntities(e1, e3)
 
-        var count = 0
-
         group = world.getGroup(EntityType.T1, EntityType.T2)
 
         group.forEach {
             assertThat(it, `is`(e1))
-            count++
         }
 
-        assertThat(count, `is`(1))
+        assertThat(group.size, `is`(1))
 
         world.removeEntities(e1, e3)
+
+        var count = 0
 
         // test Java API too
         group.forEach(Consumer { count++ })
 
-        assertThat(count, `is`(1))
+        assertThat(count, `is`(0))
     }
 
     @Test
@@ -140,20 +124,10 @@ class EntityGroupTest {
 
         world.addEntities(e1, e2)
 
-        var count = 0
-
-        group.forEach {
-            count++
-        }
-
-        assertThat(count, `is`(2))
+        assertThat(group.size, `is`(2))
 
         world.removeEntities(e1)
 
-        group.forEach {
-            count++
-        }
-
-        assertThat(count, `is`(3))
+        assertThat(group.size, `is`(1))
     }
 }

--- a/fxgl-entity/src/test/kotlin/com/almasb/fxgl/entity/EntityGroupTest.kt
+++ b/fxgl-entity/src/test/kotlin/com/almasb/fxgl/entity/EntityGroupTest.kt
@@ -85,6 +85,23 @@ class EntityGroupTest {
     }
 
     @Test
+    fun `Size`() {
+        val e1 = Entity()
+        e1.type = EntityType.T1
+
+        val e2 = Entity()
+        e2.type = EntityType.T2
+
+        world.addEntities(e1, e2)
+
+        assertThat(group.size, `is`(2))
+
+        world.removeEntities(e1)
+
+        assertThat(group.size, `is`(1))
+    }
+
+    @Test
     fun `Group only contains given entity types`() {
         val e1 = Entity()
         e1.type = EntityType.T1


### PR DESCRIPTION
Seems like a simple change.
I added a getter for the size of the entities copy list, added a test for it, and cleaned up the old tests.

