### PR TITLE
Compile version information into Java modules

### DIFF
--- a/fxgl-controllerinput/pom.xml
+++ b/fxgl-controllerinput/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>fxgl-framework</artifactId>
         <groupId>com.github.almasb</groupId>
-        <version>dev-SNAPSHOT</version>
+        <version>11+dev-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fxgl-core/pom.xml
+++ b/fxgl-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>fxgl-framework</artifactId>
         <groupId>com.github.almasb</groupId>
-        <version>dev-SNAPSHOT</version>
+        <version>11+dev-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fxgl-entity/pom.xml
+++ b/fxgl-entity/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>fxgl-framework</artifactId>
         <groupId>com.github.almasb</groupId>
-        <version>dev-SNAPSHOT</version>
+        <version>11+dev-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fxgl-gameplay/pom.xml
+++ b/fxgl-gameplay/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>fxgl-framework</artifactId>
         <groupId>com.github.almasb</groupId>
-        <version>dev-SNAPSHOT</version>
+        <version>11+dev-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fxgl-io/pom.xml
+++ b/fxgl-io/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>fxgl-framework</artifactId>
         <groupId>com.github.almasb</groupId>
-        <version>dev-SNAPSHOT</version>
+        <version>11+dev-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fxgl-samples/pom.xml
+++ b/fxgl-samples/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>fxgl-framework</artifactId>
         <groupId>com.github.almasb</groupId>
-        <version>dev-SNAPSHOT</version>
+        <version>11+dev-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fxgl-scene/pom.xml
+++ b/fxgl-scene/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>fxgl-framework</artifactId>
         <groupId>com.github.almasb</groupId>
-        <version>dev-SNAPSHOT</version>
+        <version>11+dev-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fxgl-test/pom.xml
+++ b/fxgl-test/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>fxgl-framework</artifactId>
         <groupId>com.github.almasb</groupId>
-        <version>dev-SNAPSHOT</version>
+        <version>11+dev-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fxgl-tools/pom.xml
+++ b/fxgl-tools/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>fxgl-framework</artifactId>
         <groupId>com.github.almasb</groupId>
-        <version>dev-SNAPSHOT</version>
+        <version>11+dev-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fxgl-zdeploy/pom.xml
+++ b/fxgl-zdeploy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>fxgl-framework</artifactId>
         <groupId>com.github.almasb</groupId>
-        <version>dev-SNAPSHOT</version>
+        <version>11+dev-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fxgl/pom.xml
+++ b/fxgl/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>fxgl-framework</artifactId>
         <groupId>com.github.almasb</groupId>
-        <version>dev-SNAPSHOT</version>
+        <version>11+dev-SNAPSHOT</version>
     </parent>
 
     <artifactId>fxgl</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.github.almasb</groupId>
     <artifactId>fxgl-framework</artifactId>
-    <version>dev-SNAPSHOT</version>
+    <version>11+dev-SNAPSHOT</version>
     
     <packaging>pom</packaging>
 
@@ -141,6 +141,10 @@
                     <version>${maven.compiler.version}</version>
                     <configuration>
                         <release>${source.version}</release>
+                        <compilerArgs>
+                            <arg>--module-version</arg>
+                            <arg>${project.version}</arg>
+                        </compilerArgs>
                     </configuration>
                 </plugin>
 


### PR DESCRIPTION
Prior to this commit, the version information set and managed by Maven is lost in translation. This commit configures the root compiler plugin to include the version information into the compiled Java module descriptors.

This commit also prepends `11+` to the default `dev-SNAPSHOT` version string in order to turn into a valid Java module version pattern string. For details, consult https://docs.oracle.com/en/java/javase/16/docs/api/java.base/java/lang/module/ModuleDescriptor.Version.html

Closes #1091