### PR TITLE
Enable loading of @2x images for high-dpi displays

### DIFF
--- a/fxgl/src/main/kotlin/com/almasb/fxgl/app/services/FXGLAssetLoaderService.kt
+++ b/fxgl/src/main/kotlin/com/almasb/fxgl/app/services/FXGLAssetLoaderService.kt
@@ -638,7 +638,7 @@ private class ImageAssetLoader : AssetLoader<Image>(
         TEXTURES_DIR
 ) {
     override fun load(url: URL): Image {
-        val image = url.openStream().use { Image(it) }
+        val image = Image(url.toExternalForm())
 
         if (image.isError) {
             throw image.exception
@@ -658,7 +658,7 @@ private class ResizableImageAssetLoader : AssetLoader<Image>(
     override fun load(params: LoadParams): Image {
         val loadParams = params as ResizableImageParams
 
-        val image = params.url.openStream().use { Image(it, loadParams.width, loadParams.height, false, true) }
+        val image = Image(params.url.toExternalForm(), loadParams.width, loadParams.height, false, true)
 
         if (image.isError) {
             throw image.exception


### PR DESCRIPTION
@AlmasB I struggled a lot to create games with high-res images using manual scaling. Then I found this: https://dlsc.com/2017/08/29/javafx-tip-27-hires-retina-icons/

The important part is: "_When you want to load images in code you have to make sure not to use input streams but a URL_"