### PR TITLE
build: JavaFX 18 -> 19-ea+11, Kotlin 1.6.0 -> 1.7.10, attach 4.0.13 -> 4.0.15, jackson 2.12.1 -> 2.13.3

### DIFF
--- a/fxgl-core/src/main/kotlin/com/almasb/fxgl/input/Triggers.kt
+++ b/fxgl-core/src/main/kotlin/com/almasb/fxgl/input/Triggers.kt
@@ -158,7 +158,7 @@ data class MouseTrigger
                 KeyCode.CONTROL -> modifier == InputModifier.CTRL
                 KeyCode.SHIFT -> modifier == InputModifier.SHIFT
                 KeyCode.ALT -> modifier == InputModifier.ALT
-                else -> false
+                else -> isTriggered(event)
             }
         }
 

--- a/fxgl-core/src/main/kotlin/com/almasb/fxgl/input/Triggers.kt
+++ b/fxgl-core/src/main/kotlin/com/almasb/fxgl/input/Triggers.kt
@@ -158,7 +158,7 @@ data class MouseTrigger
                 KeyCode.CONTROL -> modifier == InputModifier.CTRL
                 KeyCode.SHIFT -> modifier == InputModifier.SHIFT
                 KeyCode.ALT -> modifier == InputModifier.ALT
-                else -> modifier == InputModifier.NONE
+                else -> false
             }
         }
 

--- a/fxgl-core/src/main/kotlin/com/almasb/fxgl/input/Triggers.kt
+++ b/fxgl-core/src/main/kotlin/com/almasb/fxgl/input/Triggers.kt
@@ -152,13 +152,13 @@ data class MouseTrigger
         return event.button == button && modifier.isTriggered(event)
     }
 
-    @Suppress("NON_EXHAUSTIVE_WHEN")
     override fun isReleased(event: InputEvent): Boolean {
         if (event is KeyEvent) {
-            when (event.code) {
-                KeyCode.CONTROL -> return modifier == InputModifier.CTRL
-                KeyCode.SHIFT -> return modifier == InputModifier.SHIFT
-                KeyCode.ALT -> return modifier == InputModifier.ALT
+            return when (event.code) {
+                KeyCode.CONTROL -> modifier == InputModifier.CTRL
+                KeyCode.SHIFT -> modifier == InputModifier.SHIFT
+                KeyCode.ALT -> modifier == InputModifier.ALT
+                else -> modifier == InputModifier.NONE
             }
         }
 

--- a/fxgl/src/main/kotlin/com/almasb/fxgl/dev/Console.kt
+++ b/fxgl/src/main/kotlin/com/almasb/fxgl/dev/Console.kt
@@ -92,10 +92,10 @@ class Console : Pane() {
 
             // add any special behaving keys
             setOnKeyPressed {
-                @Suppress("NON_EXHAUSTIVE_WHEN")
                 when (it.code) {
                     KeyCode.UP -> prev()
                     KeyCode.DOWN -> next()
+                    else -> Unit
                 }
             }
 

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <maven.source.version>3.2.0</maven.source.version>
         <maven.jar.version>3.2.0</maven.jar.version>
         <maven.shade.version>3.2.2</maven.shade.version>
-        <jacoco.version>0.8.7</jacoco.version>
+        <jacoco.version>0.8.8</jacoco.version>
         <maven.surefire.version>3.0.0-M4</maven.surefire.version>
         <build.helper.version>3.0.0</build.helper.version>
         <maven.templating.version>1.0.0</maven.templating.version>

--- a/pom.xml
+++ b/pom.xml
@@ -75,29 +75,29 @@
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
 
         <!-- plugins -->
-        <maven.gpg.version>1.6</maven.gpg.version>
-        <sonatype.nexus.staging.version>1.6.8</sonatype.nexus.staging.version>
-        <maven.compiler.version>3.8.0</maven.compiler.version>
+        <maven.gpg.version>3.0.1</maven.gpg.version>
+        <sonatype.nexus.staging.version>1.6.13</sonatype.nexus.staging.version>
+        <maven.compiler.version>3.10.1</maven.compiler.version>
         <maven.pmd.version>3.15.0</maven.pmd.version>
-        <maven.license.version>3.0</maven.license.version>
-        <maven.source.version>3.2.0</maven.source.version>
-        <maven.jar.version>3.2.0</maven.jar.version>
-        <maven.shade.version>3.2.2</maven.shade.version>
-        <jacoco.version>0.8.7</jacoco.version>
-        <maven.surefire.version>3.0.0-M4</maven.surefire.version>
-        <build.helper.version>3.0.0</build.helper.version>
+        <maven.license.version>4.1</maven.license.version>
+        <maven.source.version>3.2.1</maven.source.version>
+        <maven.jar.version>3.2.2</maven.jar.version>
+        <maven.shade.version>3.3.0</maven.shade.version>
+        <jacoco.version>0.8.8</jacoco.version>
+        <maven.surefire.version>3.0.0-M7</maven.surefire.version>
+        <build.helper.version>3.3.0</build.helper.version>
         <maven.templating.version>1.0.0</maven.templating.version>
 
         <!-- dependencies -->
-        <jfx.version>18</jfx.version>
-        <kotlin.version>1.6.0</kotlin.version>
-        <attach.version>4.0.13</attach.version>
-        <jackson.version>2.12.1</jackson.version>
+        <jfx.version>19-ea+10</jfx.version>
+        <kotlin.version>1.6.21</kotlin.version>
+        <attach.version>4.0.15</attach.version>
+        <jackson.version>2.13.3</jackson.version>
 
         <!-- test dependencies -->
-        <junit.jupiter.version>5.8.2</junit.jupiter.version>
-        <junit.platform.version>1.8.2</junit.platform.version>
-        <hamcrest.version>1.3</hamcrest.version>
+        <junit.jupiter.version>5.9.0</junit.jupiter.version>
+        <junit.platform.version>1.9.0</junit.platform.version>
+        <hamcrest.version>2.2</hamcrest.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
 
         <!-- dependencies -->
         <jfx.version>19-ea+10</jfx.version>
-        <kotlin.version>1.6.21</kotlin.version>
+        <kotlin.version>1.7.10</kotlin.version>
         <attach.version>4.0.15</attach.version>
         <jackson.version>2.13.3</jackson.version>
 
@@ -105,7 +105,7 @@
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
             <version>${kotlin.version}</version>
-            <classifier>modular</classifier>
+<!--            <classifier>modular</classifier>-->
         </dependency>
 
         <!-- test scope dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <maven.templating.version>1.0.0</maven.templating.version>
 
         <!-- dependencies -->
-        <jfx.version>19-ea+10</jfx.version>
+        <jfx.version>19-ea+11</jfx.version>
         <kotlin.version>1.7.10</kotlin.version>
         <attach.version>4.0.15</attach.version>
         <jackson.version>2.13.3</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -75,17 +75,17 @@
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
 
         <!-- plugins -->
-        <maven.gpg.version>3.0.1</maven.gpg.version>
+        <maven.gpg.version>1.6</maven.gpg.version>
         <sonatype.nexus.staging.version>1.6.13</sonatype.nexus.staging.version>
-        <maven.compiler.version>3.10.1</maven.compiler.version>
+        <maven.compiler.version>3.8.0</maven.compiler.version>
         <maven.pmd.version>3.15.0</maven.pmd.version>
-        <maven.license.version>4.1</maven.license.version>
-        <maven.source.version>3.2.1</maven.source.version>
-        <maven.jar.version>3.2.2</maven.jar.version>
-        <maven.shade.version>3.3.0</maven.shade.version>
-        <jacoco.version>0.8.8</jacoco.version>
-        <maven.surefire.version>3.0.0-M7</maven.surefire.version>
-        <build.helper.version>3.3.0</build.helper.version>
+        <maven.license.version>3.0</maven.license.version>
+        <maven.source.version>3.2.0</maven.source.version>
+        <maven.jar.version>3.2.0</maven.jar.version>
+        <maven.shade.version>3.2.2</maven.shade.version>
+        <jacoco.version>0.8.7</jacoco.version>
+        <maven.surefire.version>3.0.0-M4</maven.surefire.version>
+        <build.helper.version>3.0.0</build.helper.version>
         <maven.templating.version>1.0.0</maven.templating.version>
 
         <!-- dependencies -->
@@ -95,9 +95,9 @@
         <jackson.version>2.13.3</jackson.version>
 
         <!-- test dependencies -->
-        <junit.jupiter.version>5.9.0</junit.jupiter.version>
-        <junit.platform.version>1.9.0</junit.platform.version>
-        <hamcrest.version>2.2</hamcrest.version>
+        <junit.jupiter.version>5.8.2</junit.jupiter.version>
+        <junit.platform.version>1.8.2</junit.platform.version>
+        <hamcrest.version>1.3</hamcrest.version>
     </properties>
 
     <dependencies>
@@ -105,7 +105,6 @@
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
             <version>${kotlin.version}</version>
-<!--            <classifier>modular</classifier>-->
         </dependency>
 
         <!-- test scope dependencies -->


### PR DESCRIPTION
Hi:

We tried to bump the versions of dependencies and plugins
JavaFX from 18 -> 19-ea+10, it should be fine to change the final version to 19 since the JavaFX 19 is coming to the final release candidate, won't change too much
and JavaFX 19 has an important changes which is adding new .map and .flatMap method which would be really helpful for binding style programming

Kotlin from 1.6.0 -> 1.7.10
We have to remove the modular classifier of dependency of Kotlin-stdlib
since the incremental compilation is not experimental any more
and also another significant change in the code is that
@Suppress("NON_EXHAUSTIVE_WHEN") is not available since 1.7
non exhaustive when statement will cause compilation error
so use else clause to complete the when statement

and also bump the plugins' versions

The bumped version tests have passed in my computer
<img width="1180" alt="截屏2022-08-27 上午3 51 51" src="https://user-images.githubusercontent.com/5525436/186981813-920b402d-1eae-40c2-bf2d-70d7164dbe28.png">


Cheers