### PR TITLE
build: Kotlin 1.7.10 -> 1.8.0, Jackson 2.13.4 -> 2.14.1, github-action checkout/setup-java/cache v1,v2 -> v3, Attach 4.0.15 -> 4.0.16

### DIFF
--- a/.github/workflows/deploy_SNAPSHOT.yml
+++ b/.github/workflows/deploy_SNAPSHOT.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up JDK 17
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
         java-version: 17
         server-id: ossrh

--- a/.github/workflows/deploy_SNAPSHOT.yml
+++ b/.github/workflows/deploy_SNAPSHOT.yml
@@ -15,6 +15,7 @@ jobs:
     - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
+        distribution: 'temurin'
         java-version: 17
         server-id: ossrh
         server-username: MAVEN_USERNAME

--- a/.github/workflows/latest_jdk.yml
+++ b/.github/workflows/latest_jdk.yml
@@ -22,6 +22,7 @@ jobs:
       - name: 'Set up JDK'
         uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
 
       - name: Cache maven deps

--- a/.github/workflows/latest_jdk.yml
+++ b/.github/workflows/latest_jdk.yml
@@ -17,15 +17,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: 'Set up JDK'
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
 
       - name: Cache maven deps
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/latest_jdk.yml
+++ b/.github/workflows/latest_jdk.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macOS-latest, windows-latest ]
-        java: [ 20-ea ]
+        java: [ 19-ea ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: 'Checkout'

--- a/.github/workflows/latest_jdk.yml
+++ b/.github/workflows/latest_jdk.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macOS-latest, windows-latest ]
-        java: [ 19-ea ]
+        java: [ 20-ea ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: 'Checkout'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       
     - name: Set up latest stable JDK
       uses: actions/setup-java@v1
@@ -20,7 +20,7 @@ jobs:
         java-version: 17
 
     - name: Cache maven deps
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,8 +15,9 @@ jobs:
     - uses: actions/checkout@v3
       
     - name: Set up latest stable JDK
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
+        distribution: 'temurin'
         java-version: 17
 
     - name: Cache maven deps

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <jfx.version>19</jfx.version>
         <kotlin.version>1.7.22</kotlin.version>
         <attach.version>4.0.15</attach.version>
-        <jackson.version>2.14.0</jackson.version>
+        <jackson.version>2.14.1</jackson.version>
 
         <!-- test dependencies -->
         <junit.jupiter.version>5.8.2</junit.jupiter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
 
         <!-- dependencies -->
         <jfx.version>19</jfx.version>
-        <kotlin.version>1.7.21</kotlin.version>
+        <kotlin.version>1.7.22</kotlin.version>
         <attach.version>4.0.15</attach.version>
         <jackson.version>2.14.0</jackson.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -90,8 +90,8 @@
 
         <!-- dependencies -->
         <jfx.version>19</jfx.version>
-        <kotlin.version>1.7.22</kotlin.version>
-        <attach.version>4.0.15</attach.version>
+        <kotlin.version>1.8.0</kotlin.version>
+        <attach.version>4.0.16</attach.version>
         <jackson.version>2.14.1</jackson.version>
 
         <!-- test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -90,9 +90,9 @@
 
         <!-- dependencies -->
         <jfx.version>19</jfx.version>
-        <kotlin.version>1.7.10</kotlin.version>
+        <kotlin.version>1.7.21</kotlin.version>
         <attach.version>4.0.15</attach.version>
-        <jackson.version>2.13.4</jackson.version>
+        <jackson.version>2.14.0</jackson.version>
 
         <!-- test dependencies -->
         <junit.jupiter.version>5.8.2</junit.jupiter.version>


### PR DESCRIPTION
Hi:

Today, Kotlin and Jackson release new version jars
and Jackson 2.13.4 has one [vulnerability](https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind/2.13.4) so we should better to upgrade it asap

for github action,
github action is deprecating checkout/setup-java/cache v1 & v2
so it has to upgrade to v3 otherwise the github action may not working in near future

Cheers