### PR TITLE
build: JavaFX 19 -> 19.0.2.1

### DIFF
--- a/.github/workflows/deploy_SNAPSHOT.yml
+++ b/.github/workflows/deploy_SNAPSHOT.yml
@@ -24,7 +24,7 @@ jobs:
         gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
     - name: Cache maven deps
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <maven.templating.version>1.0.0</maven.templating.version>
 
         <!-- dependencies -->
-        <jfx.version>19</jfx.version>
+        <jfx.version>19.0.2.1</jfx.version>
         <kotlin.version>1.8.0</kotlin.version>
         <attach.version>4.0.16</attach.version>
         <jackson.version>2.14.1</jackson.version>


### PR DESCRIPTION
There is a bug which may cause JavaFX on Mac crash & JavaFX 19.0.2.1 fix this bug
see also:
https://github.com/openjdk/jfx/pull/1003