### PR TITLE
fix: Use effective tpf value in LoopRunner (onUpdate)

### DIFF
--- a/fxgl/src/main/kotlin/com/almasb/fxgl/app/Engine.kt
+++ b/fxgl/src/main/kotlin/com/almasb/fxgl/app/Engine.kt
@@ -25,7 +25,7 @@ internal class Engine(val settings: ReadOnlyGameSettings) {
 
     private val log = Logger.get(javaClass)
 
-    private val loop = LoopRunner(settings.ticksPerSecond) { loop(it) }
+    private val loop = LoopRunner(settings.ticksPerSecond, settings.fpsRefreshRate) { loop(it) }
 
     val tpf: Double
         get() = loop.tpf

--- a/fxgl/src/main/kotlin/com/almasb/fxgl/app/LoopRunner.kt
+++ b/fxgl/src/main/kotlin/com/almasb/fxgl/app/LoopRunner.kt
@@ -9,6 +9,7 @@ package com.almasb.fxgl.app
 import com.almasb.fxgl.logging.Logger
 import javafx.animation.AnimationTimer
 import javafx.application.Platform
+import javafx.util.Duration
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import kotlin.system.measureNanoTime
@@ -28,6 +29,8 @@ internal class LoopRunner(
          * to the display refresh rate.
          */
         private val ticksPerSecond: Int = -1,
+
+        private val fpsRefreshRate: Duration = Duration.millis(500.0),
 
         private val runnable: (Double) -> Unit) {
 
@@ -94,7 +97,7 @@ internal class LoopRunner(
     }
 
     private fun frame(now: Long) {
-        val ticksPerSecond = if (ticksPerSecond < 0) 60 else ticksPerSecond // For JavaFX loops, cap at 60fps too
+        val ticksPerSecond = if (ticksPerSecond < 0) 60 else ticksPerSecond // When unknown, default to 60 fps
 
         if (lastFrameNanos == 0L) {
             lastFrameNanos = now - (1_000_000_000.0 / ticksPerSecond).toLong()
@@ -112,9 +115,9 @@ internal class LoopRunner(
 
         fpsSamplingCount++
 
-        // Update the FPS value every 500 millis
+        // Update the FPS value based on provided refresh rate
         val timeSinceLastFPSUpdateNanos = now - lastFPSUpdateNanos;
-        if (timeSinceLastFPSUpdateNanos >= 500_000_000) {
+        if (timeSinceLastFPSUpdateNanos >= fpsRefreshRate.toMillis() * 1_000_000) {
             lastFPSUpdateNanos = now
             fps = (fpsSamplingCount.toLong() * 1_000_000_000 / timeSinceLastFPSUpdateNanos).toInt()
             fpsSamplingCount = 0

--- a/fxgl/src/main/kotlin/com/almasb/fxgl/app/Settings.kt
+++ b/fxgl/src/main/kotlin/com/almasb/fxgl/app/Settings.kt
@@ -40,6 +40,7 @@ import javafx.beans.property.*
 import javafx.scene.input.KeyCode
 import javafx.scene.paint.Color
 import javafx.stage.StageStyle
+import javafx.util.Duration
 import java.util.*
 import java.util.Collections.unmodifiableList
 import kotlin.math.roundToInt
@@ -270,6 +271,12 @@ class GameSettings(
         var ticksPerSecond: Int = -1,
 
         /**
+         * Rate (time) between each FPS sampling update.
+         * Default value is 500 millis
+         */
+        var fpsRefreshRate: Duration = Duration.millis(500.0),
+
+        /**
          * How fast the 3D mouse movements are (example, rotating the camera).
          */
         var mouseSensitivity: Double = 0.2,
@@ -402,6 +409,7 @@ class GameSettings(
                 secondsIn24h,
                 randomSeed,
                 ticksPerSecond,
+                fpsRefreshRate,
                 userAppClass,
                 mouseSensitivity,
                 defaultLanguage,
@@ -582,6 +590,8 @@ class ReadOnlyGameSettings internal constructor(
         val randomSeed: Long,
 
         val ticksPerSecond: Int,
+
+        val fpsRefreshRate: Duration,
 
         val userAppClass: Class<*>,
 

--- a/fxgl/src/test/kotlin/com/almasb/fxgl/app/GameSettingsTest.kt
+++ b/fxgl/src/test/kotlin/com/almasb/fxgl/app/GameSettingsTest.kt
@@ -11,6 +11,7 @@ import com.almasb.fxgl.core.util.Platform
 import com.almasb.fxgl.test.RunWithFX
 import javafx.scene.input.KeyCode
 import javafx.stage.Stage
+import javafx.util.Duration
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.CoreMatchers.hasItems
 import org.hamcrest.MatcherAssert.assertThat
@@ -87,6 +88,7 @@ class GameSettingsTest {
         assertThat(settings.menuKey, `is`(KeyCode.ENTER))
         assertThat(settings.credits, hasItems("TestCredit1", "TestCredit2"))
         assertThat(settings.applicationMode, `is`(ApplicationMode.RELEASE))
+        assertThat(settings.fpsRefreshRate, `is`(Duration.millis(500.0)))
 
         assertTrue(settings.isDesktop)
         assertFalse(settings.isBrowser)

--- a/fxgl/src/test/kotlin/com/almasb/fxgl/app/LoopRunnerTest.kt
+++ b/fxgl/src/test/kotlin/com/almasb/fxgl/app/LoopRunnerTest.kt
@@ -138,11 +138,11 @@ class LoopRunnerTest {
         }
 
         // We processed approximately 100 frames (150 where in Pause)
-        assertThat(count1, greaterThan((98 * frameTime).toDouble() / 1_000))
-        assertThat(count1, lessThan((102 * frameTime).toDouble() / 1_000))
+        assertThat(count1, greaterThan((90 * frameTime).toDouble() / 1_000))
+        assertThat(count1, lessThan((110 * frameTime).toDouble() / 1_000))
 
-        assertThat(count2, greaterThan((98 * frameTime).toDouble() / 1_000))
-        assertThat(count2, lessThan((102 * frameTime).toDouble() / 1_000))
+        assertThat(count2, greaterThan((90 * frameTime).toDouble() / 1_000))
+        assertThat(count2, lessThan((110 * frameTime).toDouble() / 1_000))
     }
 
     @Test

--- a/fxgl/src/test/kotlin/com/almasb/fxgl/app/LoopRunnerTest.kt
+++ b/fxgl/src/test/kotlin/com/almasb/fxgl/app/LoopRunnerTest.kt
@@ -121,8 +121,8 @@ class LoopRunnerTest {
         ).forEach {
             it.start()
 
-            // 16.6 per frame, so 10 frames
-            Thread.sleep(frameTime * 10)
+            // 16.6 per frame, so 50 frames
+            Thread.sleep(frameTime * 50)
 
             it.pause()
 
@@ -131,18 +131,18 @@ class LoopRunnerTest {
 
             it.resume()
 
-            // 16.6 per frame, so 10 frames
-            Thread.sleep(frameTime * 10)
+            // 16.6 per frame, so 50 frames
+            Thread.sleep(frameTime * 50)
 
             it.stop()
         }
 
-        // We processed 170 frames
-        assertThat(count1, greaterThan((169 * frameTime).toDouble() / 1_000))
-        assertThat(count1, lessThan((171 * frameTime).toDouble() / 1_000))
+        // We processed approximately 100 frames (150 where in Pause)
+        assertThat(count1, greaterThan((98 * frameTime).toDouble() / 1_000))
+        assertThat(count1, lessThan((102 * frameTime).toDouble() / 1_000))
 
-        assertThat(count2, greaterThan((169 * frameTime).toDouble() / 1_000))
-        assertThat(count2, lessThan((171 * frameTime).toDouble() / 1_000))
+        assertThat(count2, greaterThan((98 * frameTime).toDouble() / 1_000))
+        assertThat(count2, lessThan((102 * frameTime).toDouble() / 1_000))
     }
 
     @Test

--- a/fxgl/src/test/kotlin/com/almasb/fxgl/app/LoopRunnerTest.kt
+++ b/fxgl/src/test/kotlin/com/almasb/fxgl/app/LoopRunnerTest.kt
@@ -146,4 +146,53 @@ class LoopRunnerTest {
         assertThat(count2, greaterThan(0.0))
         assertThat(count2, lessThan(0.75))
     }
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "CI", matches = "true")
+    fun `Lag Recovery`() {
+        var t = 0.0
+        var lag = 250L
+
+        listOf(
+            // run with a given ticks per second (via scheduled service tick)
+            LoopRunner(60) { t += it; Thread.sleep(lag) },
+
+            // run with display refresh rate (via JavaFX pulse tick)
+            LoopRunner { t += it; Thread.sleep(lag) }
+        ).forEach { loop ->
+            t = 0.0
+
+            loop.start()
+
+            Thread.sleep(2500)  // Sample for more than 2 seconds, to cover the 2SecsBuffer case
+
+            loop.pause()
+
+            // We know that a single tick will take at least "lag" millis, so TPFs should be around 200 millis
+            assertThat(loop.tpf, closeTo(lag.toDouble() / 1000.0, 0.02))
+
+            // The game loop should have completed 2.5 seconds of game time at this stage
+            assertThat(t, closeTo(2.5, 0.2))
+
+            lag = 1L  // Stop Lag
+
+            loop.resume()
+
+            Thread.sleep(1000)
+
+            loop.stop()
+
+            // The 2 seconds Buffer shouldn't cause tpf to be 200 millis anymore
+            assertThat(loop.tpf, closeTo(0.016, 0.09))
+
+            assertThat(t, closeTo(3.5, 0.4))
+
+            // shouldn't change anything since loop is stopped
+            Thread.sleep(300)
+
+            assertThat(loop.tpf, closeTo(0.016, 0.09))
+
+            assertThat(t, closeTo(3.5, 0.4))
+        }
+    }
 }

--- a/fxgl/src/test/kotlin/com/almasb/fxgl/app/LoopRunnerTest.kt
+++ b/fxgl/src/test/kotlin/com/almasb/fxgl/app/LoopRunnerTest.kt
@@ -106,59 +106,54 @@ class LoopRunnerTest {
     fun `LoopRunner resets ticks after pause`() {
         var count1 = 0.0
         var count2 = 0.0
+        val frameTime = 1_000L / 60
 
         listOf(
                 // run with a given ticks per second (via scheduled service tick)
                 LoopRunner(60) {
-
                     count1 += it
                 },
 
                 // run with display refresh rate (via JavaFX pulse tick)
                 LoopRunner {
-
                     count2 += it
                 }
         ).forEach {
             it.start()
 
             // 16.6 per frame, so 10 frames
-            Thread.sleep(166)
+            Thread.sleep(frameTime * 10)
 
             it.pause()
 
             // sleep for 150 frames = 2.5 sec
-            Thread.sleep(166 * 15)
+            Thread.sleep(frameTime * 150)
 
             it.resume()
 
             // 16.6 per frame, so 10 frames
-            Thread.sleep(166)
+            Thread.sleep(frameTime * 10)
 
             it.stop()
         }
 
-        // in total we should have computed 20 frames, ~20 * 0.017 = ~0.34
+        // We processed 170 frames
+        assertThat(count1, greaterThan((169 * frameTime).toDouble() / 1_000))
+        assertThat(count1, lessThan((171 * frameTime).toDouble() / 1_000))
 
-        assertThat(count1, greaterThan(0.0))
-        assertThat(count1, lessThan(0.75))
-
-        assertThat(count2, greaterThan(0.0))
-        assertThat(count2, lessThan(0.75))
+        assertThat(count2, greaterThan((169 * frameTime).toDouble() / 1_000))
+        assertThat(count2, lessThan((171 * frameTime).toDouble() / 1_000))
     }
 
     @Test
     @EnabledIfEnvironmentVariable(named = "CI", matches = "true")
     fun `Lag Recovery`() {
         var t = 0.0
-        var lag = 250L
+        var lag = 200L
 
         listOf(
             // run with a given ticks per second (via scheduled service tick)
-            LoopRunner(60) { t += it; Thread.sleep(lag) },
-
-            // run with display refresh rate (via JavaFX pulse tick)
-            LoopRunner { t += it; Thread.sleep(lag) }
+            LoopRunner(60) { t += it; Thread.sleep(lag) }
         ).forEach { loop ->
             t = 0.0
 
@@ -170,6 +165,7 @@ class LoopRunnerTest {
 
             // We know that a single tick will take at least "lag" millis, so TPFs should be around 200 millis
             assertThat(loop.tpf, closeTo(lag.toDouble() / 1000.0, 0.02))
+            assertThat(loop.fps.toDouble(), closeTo(5.0, 1.0))
 
             // The game loop should have completed 2.5 seconds of game time at this stage
             assertThat(t, closeTo(2.5, 0.2))
@@ -178,7 +174,7 @@ class LoopRunnerTest {
 
             loop.resume()
 
-            Thread.sleep(1000)
+            Thread.sleep(1000)  // Need to wait at least 2 seconds for the FPS sampling to recalculate
 
             loop.stop()
 


### PR DESCRIPTION
Hi,

Issue Link: #1297 

This PR contains fixes for the FPS & the TPF calculations. The FPS calculation is now refreshed every 500 millis. The TPF will be based on current TPF.

Note that this change was a game changer. I was experiencing frequent freeze and FPS issues (I was wondering also why the Profiler was showing 60 steady FPS when it was lagging). With this change, the Profiler will show realtime FPS and recover from lag instantly (when possible).