### PR TITLE
fix: Prevent custom Cursor texture from getting corrupted when going back to the MainMenu

### DIFF
--- a/fxgl/src/main/kotlin/com/almasb/fxgl/app/FXGLApplication.kt
+++ b/fxgl/src/main/kotlin/com/almasb/fxgl/app/FXGLApplication.kt
@@ -655,8 +655,6 @@ class FXGLApplication : Application() {
                 return
             }
 
-            // since mainMenu is a subscene we need an actual scene before it
-            mainWindow.setScene(dummyScene)
             mainWindow.pushState(mainMenu!!)
         }
 


### PR DESCRIPTION
Hi,

Issue Link: #1299 

By keeping the current scene intact (instead of switching to DummyScene), we prevent texture mixing.