### PR TITLE
feat: Allow volume control of Music & Sound with property

### DIFF
--- a/fxgl-core/src/main/kotlin/com/almasb/fxgl/audio/AudioPlayer.kt
+++ b/fxgl-core/src/main/kotlin/com/almasb/fxgl/audio/AudioPlayer.kt
@@ -11,7 +11,6 @@ import com.almasb.fxgl.core.EngineService
 import com.almasb.fxgl.core.Inject
 import com.almasb.fxgl.core.collection.UnorderedArray
 import com.almasb.fxgl.logging.Logger
-import javafx.beans.property.DoubleProperty
 import java.net.URL
 
 /**
@@ -27,26 +26,10 @@ class AudioPlayer : EngineService() {
     private val activeMusic = UnorderedArray<Music>()
     private val activeSounds = UnorderedArray<Sound>()
 
-    @Inject("globalMusicVolumeProperty")
-    private lateinit var musicVolume: DoubleProperty
-
-    @Inject("globalSoundVolumeProperty")
-    private lateinit var soundVolume: DoubleProperty
-
     @Inject("isPauseMusicWhenMinimized")
     private var isPauseMusicWhenMinimized = true
 
     private val loader = DesktopAndMobileAudioLoader()
-
-    override fun onMainLoopStarting() {
-        musicVolume.addListener { _, _, newVolume ->
-            activeMusic.forEach { it.audio.setVolume(newVolume.toDouble()) }
-        }
-
-        soundVolume.addListener { _, _, newVolume ->
-            activeSounds.forEach { it.audio.setVolume(newVolume.toDouble()) }
-        }
-    }
 
     override fun onMainLoopPausing() {
         if (isPauseMusicWhenMinimized) {
@@ -74,7 +57,6 @@ class AudioPlayer : EngineService() {
         if (!activeSounds.containsByIdentity(sound))
             activeSounds.add(sound)
 
-        sound.audio.setVolume(soundVolume.value)
         sound.audio.play()
     }
 
@@ -106,7 +88,6 @@ class AudioPlayer : EngineService() {
             activeMusic.add(music)
         }
 
-        music.audio.setVolume(musicVolume.value)
         music.audio.play()
     }
 
@@ -192,4 +173,5 @@ class AudioPlayer : EngineService() {
     fun loadAudio(audioType: AudioType, url: URL, isMobile: Boolean): Audio {
         return loader.loadAudio(audioType, url, isMobile)
     }
+
 }

--- a/fxgl-core/src/main/kotlin/com/almasb/fxgl/audio/impl/DesktopAndMobileAudioLoader.kt
+++ b/fxgl-core/src/main/kotlin/com/almasb/fxgl/audio/impl/DesktopAndMobileAudioLoader.kt
@@ -66,7 +66,7 @@ class DesktopAndMobileAudioLoader : AudioLoader {
             }
 
             override fun setVolume(volume: Double) {
-                nativeAudio.ifPresent { it.setVolume(volume) }
+                nativeAudio.ifPresent { it.setVolume(mix(volume)) }
             }
 
             override fun setOnFinished(action: Runnable) {

--- a/fxgl-core/src/main/kotlin/com/almasb/fxgl/audio/impl/DesktopAudio.kt
+++ b/fxgl-core/src/main/kotlin/com/almasb/fxgl/audio/impl/DesktopAudio.kt
@@ -21,7 +21,7 @@ class DesktopMusic(private val mediaPlayer: MediaPlayer) : Audio(AudioType.MUSIC
     }
 
     override fun setVolume(volume: Double) {
-        mediaPlayer.volume = volume
+        mediaPlayer.volume = mix(volume)
     }
 
     override fun setOnFinished(action: Runnable) {
@@ -52,7 +52,7 @@ class DesktopSound(private val clip: AudioClip) : Audio(AudioType.SOUND) {
     }
 
     override fun setVolume(volume: Double) {
-        clip.volume = volume
+        clip.volume = mix(volume)
     }
 
     override fun setOnFinished(action: Runnable) {

--- a/fxgl/src/main/kotlin/com/almasb/fxgl/app/Settings.kt
+++ b/fxgl/src/main/kotlin/com/almasb/fxgl/app/Settings.kt
@@ -11,6 +11,7 @@ import com.almasb.fxgl.achievement.AchievementService
 import com.almasb.fxgl.app.scene.SceneFactory
 import com.almasb.fxgl.app.services.*
 import com.almasb.fxgl.audio.AudioPlayer
+import com.almasb.fxgl.audio.AudioType
 import com.almasb.fxgl.core.EngineService
 import com.almasb.fxgl.core.math.FXGLMath
 import com.almasb.fxgl.core.serialization.Bundle
@@ -765,28 +766,6 @@ class ReadOnlyGameSettings internal constructor(
         get() = gameDifficultyProp.value
         set(value) { gameDifficultyProp.value = value }
 
-    @get:JvmName("globalMusicVolumeProperty")
-    val globalMusicVolumeProperty = SimpleDoubleProperty(0.5)
-
-    /**
-     * Set global music volume in the range [0..1],
-     * where 0 = 0%, 1 = 100%.
-     */
-    var globalMusicVolume: Double
-        get() = globalMusicVolumeProperty.value
-        set(value) { globalMusicVolumeProperty.value = value }
-
-    @get:JvmName("globalSoundVolumeProperty")
-    val globalSoundVolumeProperty = SimpleDoubleProperty(0.5)
-
-    /**
-     * Set global sound volume in the range [0..1],
-     * where 0 = 0%, 1 = 100%.
-     */
-    var globalSoundVolume: Double
-        get() = globalSoundVolumeProperty.value
-        set(value) { globalSoundVolumeProperty.value = value }
-
     private val mouseSensitivityProp = SimpleDoubleProperty(mouseSensitivity)
 
     var mouseSensitivity: Double
@@ -804,15 +783,16 @@ class ReadOnlyGameSettings internal constructor(
 
     override fun write(bundle: Bundle) {
         bundle.put("fullscreen", fullScreen.value)
-        bundle.put("globalMusicVolume", globalMusicVolume)
-        bundle.put("globalSoundVolume", globalSoundVolume)
+
+        bundle.put("globalMusicVolume", AudioType.MUSIC.volume.value)
+        bundle.put("globalSoundVolume", AudioType.SOUND.volume.value)
     }
 
     override fun read(bundle: Bundle) {
         fullScreen.value = bundle.get("fullscreen")
 
-        globalMusicVolume = bundle.get("globalMusicVolume")
-        globalSoundVolume = bundle.get("globalSoundVolume")
+        AudioType.MUSIC.volume.value = bundle.get("globalMusicVolume")
+        AudioType.SOUND.volume.value = bundle.get("globalSoundVolume")
 
         applySettings()
     }

--- a/fxgl/src/main/kotlin/com/almasb/fxgl/app/scene/FXGLDefaultMenu.kt
+++ b/fxgl/src/main/kotlin/com/almasb/fxgl/app/scene/FXGLDefaultMenu.kt
@@ -10,6 +10,7 @@ import com.almasb.fxgl.animation.Animation
 import com.almasb.fxgl.animation.Interpolators
 import com.almasb.fxgl.app.ApplicationMode
 import com.almasb.fxgl.app.MenuItem
+import com.almasb.fxgl.audio.AudioType
 import com.almasb.fxgl.core.math.FXGLMath.noise1D
 import com.almasb.fxgl.core.util.InputPredicates
 import com.almasb.fxgl.dsl.*
@@ -699,7 +700,7 @@ open class FXGLDefaultMenu(type: MenuType) : FXGLMenu(type) {
         val sliderMusic = getUIFactoryService().newSlider()
         sliderMusic.min = 0.0
         sliderMusic.max = 1.0
-        sliderMusic.valueProperty().bindBidirectional(getSettings().globalMusicVolumeProperty)
+        sliderMusic.valueProperty().bindBidirectional(AudioType.MUSIC.volume)
 
         val textMusic = getUIFactoryService().newText(localizedStringProperty("menu.music.volume").concat(": "))
         val percentMusic = getUIFactoryService().newText("")
@@ -708,7 +709,7 @@ open class FXGLDefaultMenu(type: MenuType) : FXGLMenu(type) {
         val sliderSound = getUIFactoryService().newSlider()
         sliderSound.min = 0.0
         sliderSound.max = 1.0
-        sliderSound.valueProperty().bindBidirectional(getSettings().globalSoundVolumeProperty)
+        sliderSound.valueProperty().bindBidirectional(AudioType.SOUND.volume)
 
         val textSound = getUIFactoryService().newText(localizedStringProperty("menu.sound.volume").concat(": "))
         val percentSound = getUIFactoryService().newText("")


### PR DESCRIPTION
Hi,

Issue Link: https://github.com/AlmasB/FXGL/issues/1310

Here's an implementation that allow custom Volume configuration of all Sounds & Musics. I've placed the "Master / Global" volume property of the AudioType inside them. This felt pretty natural since the "expert" (GRAPS) of that information is the AudioType itself. This also mean that we could really easily add a new AudioType without much efforts and that new type would automatically mix itself against the Global and the current Audio.

@AlmasB NOTE: I took the initiative to revert the changes made in #1187. Granting access to the internal audio is causing a bug related to volume adjustments in the settings. Whenever a player was adjusting his Global volume, all custom changes made on the audio (getAudio()) was automatically reverted. With this implementation, the conjunction of the 2 values are always kept (via the mix() method)

Example:
```
Music music = getAssetLoader().loadMusic("rain.mp3");
music.setVolume(0.0);
Timeline timeline = new Timeline(
    new KeyFrame(Duration.seconds(5),
    new KeyValue(music.volumeProperty(), 1.0))
);
FXGL.getAudioPlayer().playMusic(music);
timeline.play();
```

Note that changing the Global Music volume will also automatically impact all Music:
```
AudioType.MUSIC.getVolume().set(AudioType.MUSIC.getVolume().get() - 0.1);
```

I've tested it on my own game and I needed it!
I hope you like it! :) 