### PR TITLE
fix: Emit particles at initial Entity zIndex instead of zIndex 0

### DIFF
--- a/fxgl-entity/src/main/kotlin/com/almasb/fxgl/particle/ParticleComponent.kt
+++ b/fxgl-entity/src/main/kotlin/com/almasb/fxgl/particle/ParticleComponent.kt
@@ -36,6 +36,7 @@ open class ParticleComponent(val emitter: ParticleEmitter) : Component() {
 
     override fun onUpdate(tpf: Double) {
         if (parent.world == null) {
+            parent.zIndex = entity.zIndex
             entity.world.addEntity(parent)
         }
 

--- a/fxgl-entity/src/test/kotlin/com/almasb/fxgl/particle/ParticleComponentTest.kt
+++ b/fxgl-entity/src/test/kotlin/com/almasb/fxgl/particle/ParticleComponentTest.kt
@@ -13,7 +13,6 @@ import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -24,34 +23,34 @@ import org.junit.jupiter.api.Test
 class ParticleComponentTest {
 
     private lateinit var world: GameWorld
-    private lateinit var particule: ParticleComponent
+    private lateinit var particle: ParticleComponent
 
     @BeforeEach
     fun setUp() {
         world = GameWorld()
-        particule = ParticleComponent(ParticleEmitter())
+        particle = ParticleComponent(ParticleEmitter())
     }
 
     @Test
-    fun `Create ParticuleComponent with zIndex`() {
-        assertNull(particule.entity)
-        assertNotNull(particule.parent)
-        assertThat(particule.parent.zIndex, `is`(0))
+    fun `Create ParticleComponent with zIndex`() {
+        assertNull(particle.entity)
+        assertNotNull(particle.parent)
+        assertThat(particle.parent.zIndex, `is`(0))
 
         val e = Entity()
         e.zIndex = 100
 
-        ComponentHelper.setEntity(particule, e)
+        ComponentHelper.setEntity(particle, e)
         world.addEntity(e)
-        particule.onAdded()
-        particule.onUpdate(1.0)
+        particle.onAdded()
+        particle.onUpdate(1.0)
 
-        assertThat(particule.parent.zIndex, `is`(100))
+        assertThat(particle.parent.zIndex, `is`(100))
 
         e.zIndex = 200
-        particule.onUpdate(1.0)
+        particle.onUpdate(1.0)
 
-        assertThat(particule.parent.zIndex, `is`(100))
+        assertThat(particle.parent.zIndex, `is`(100))
     }
 
 }

--- a/fxgl-entity/src/test/kotlin/com/almasb/fxgl/particle/ParticleComponentTest.kt
+++ b/fxgl-entity/src/test/kotlin/com/almasb/fxgl/particle/ParticleComponentTest.kt
@@ -1,0 +1,57 @@
+/*
+ * FXGL - JavaFX Game Library. The MIT License (MIT).
+ * Copyright (c) AlmasB (almaslvl@gmail.com).
+ * See LICENSE for details.
+ */
+@file:Suppress("JAVA_MODULE_DOES_NOT_DEPEND_ON_MODULE")
+package com.almasb.fxgl.particle
+
+import com.almasb.fxgl.entity.Entity
+import com.almasb.fxgl.entity.GameWorld
+import com.almasb.fxgl.entity.component.ComponentHelper
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ *
+ * @author Jean-Rene Lavoie (jeanrlavoie@gmail.com)
+ */
+class ParticleComponentTest {
+
+    private lateinit var world: GameWorld
+    private lateinit var particule: ParticleComponent
+
+    @BeforeEach
+    fun setUp() {
+        world = GameWorld()
+        particule = ParticleComponent(ParticleEmitter())
+    }
+
+    @Test
+    fun `Create ParticuleComponent with zIndex`() {
+        assertNull(particule.entity)
+        assertNotNull(particule.parent)
+        assertThat(particule.parent.zIndex, `is`(0))
+
+        val e = Entity()
+        e.zIndex = 100
+
+        ComponentHelper.setEntity(particule, e)
+        world.addEntity(e)
+        particule.onAdded()
+        particule.onUpdate(1.0)
+
+        assertThat(particule.parent.zIndex, `is`(100))
+
+        e.zIndex = 200
+        particule.onUpdate(1.0)
+
+        assertThat(particule.parent.zIndex, `is`(100))
+    }
+
+}


### PR DESCRIPTION
Hi @AlmasB,
Here is the PR for the Bug #1318 
Thanks,