### PR TITLE
feat: Support diagonal pathfinding movement

### DIFF
--- a/fxgl-core/src/main/java/com/almasb/fxgl/core/collection/grid/Diagonal.java
+++ b/fxgl-core/src/main/java/com/almasb/fxgl/core/collection/grid/Diagonal.java
@@ -1,5 +1,17 @@
+/*
+ * FXGL - JavaFX Game Library. The MIT License (MIT).
+ * Copyright (c) AlmasB (almaslvl@gmail.com).
+ * See LICENSE for details.
+ */
+
 package com.almasb.fxgl.core.collection.grid;
 
+
+/**
+ * Define Diagonal Movement mode
+ *
+ * @author Jean-Rene Lavoie (jeanrlavoie@gmail.com)
+ */
 public enum Diagonal {
 
     NEVER, ALLOWED;

--- a/fxgl-core/src/main/java/com/almasb/fxgl/core/collection/grid/Diagonal.java
+++ b/fxgl-core/src/main/java/com/almasb/fxgl/core/collection/grid/Diagonal.java
@@ -1,0 +1,16 @@
+package com.almasb.fxgl.core.collection.grid;
+
+public enum Diagonal {
+
+    NEVER, ALLOWED;
+
+    public boolean is(Diagonal... diagonalMovements) {
+        for(Diagonal diagonalMovement : diagonalMovements) {
+            if(diagonalMovement.equals(this)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/fxgl-core/src/main/java/com/almasb/fxgl/core/collection/grid/Grid.java
+++ b/fxgl-core/src/main/java/com/almasb/fxgl/core/collection/grid/Grid.java
@@ -234,19 +234,19 @@ public class Grid<T extends Cell> {
     }
 
     public final Optional<T> getUpRight(int x, int y) {
-        return getOptional(x + 1, y + 1);
-    }
-
-    public final Optional<T> getUpLeft(int x, int y) {
-        return getOptional(x - 1, y + 1);
-    }
-
-    public final Optional<T> getDownRight(int x, int y) {
         return getOptional(x + 1, y - 1);
     }
 
-    public final Optional<T> getDownLeft(int x, int y) {
+    public final Optional<T> getUpLeft(int x, int y) {
         return getOptional(x - 1, y - 1);
+    }
+
+    public final Optional<T> getDownRight(int x, int y) {
+        return getOptional(x + 1, y + 1);
+    }
+
+    public final Optional<T> getDownLeft(int x, int y) {
+        return getOptional(x - 1, y + 1);
     }
 
     /**

--- a/fxgl-core/src/test/java/com/almasb/fxgl/core/collection/grid/GridTest.java
+++ b/fxgl-core/src/test/java/com/almasb/fxgl/core/collection/grid/GridTest.java
@@ -143,6 +143,16 @@ public class GridTest {
     }
 
     @Test
+    public void testGetDiagonalNeighbors() {
+        grid.setDiagonal(Diagonal.ALLOWED);
+        assertThat(grid.getNeighbors( 3,3), containsInAnyOrder(
+            grid.get(2, 2),  grid.get(2, 3), grid.get(2, 4),
+            grid.get(3, 2), grid.get(3, 4),  // Doesn't contain 3, 3 (self)
+            grid.get(4, 2), grid.get(4, 3), grid.get(4, 4)
+        ));
+    }
+
+    @Test
     public void testGetRandomCell() {
         for (int i = 0; i < 50; i++) {
             assertNotNull(grid.getRandomCell());

--- a/fxgl-core/src/test/java/com/almasb/fxgl/core/collection/grid/GridTest.java
+++ b/fxgl-core/src/test/java/com/almasb/fxgl/core/collection/grid/GridTest.java
@@ -219,6 +219,57 @@ public class GridTest {
         assertThat(grid.getDown(grid.get(1,  GRID_SIZE - 1)).isPresent(), is(false));
     }
 
+    @Test
+    public void testDiagonals() {
+        // up right cell
+        Optional<MockCell> upRightCell = grid.getUpRight(grid.get(1, 1));
+
+        assertThat(upRightCell.isPresent(), is(true));
+        assertThat(upRightCell.get().getX(), is(2));
+        assertThat(upRightCell.get().getY(), is(0));
+
+        assertThat(grid.getUpRight(grid.get(0, 0)).isPresent(), is(false));
+        assertThat(grid.getUpRight(grid.get(0, GRID_SIZE-1)).isPresent(), is(true));
+        assertThat(grid.getUpRight(grid.get(GRID_SIZE-1, 0)).isPresent(), is(false));
+        assertThat(grid.getUpRight(grid.get(GRID_SIZE-1, GRID_SIZE-1)).isPresent(), is(false));
+
+        // up left Cell
+        Optional<MockCell> upLeftCell = grid.getUpLeft(grid.get(1, 1));
+
+        assertThat(upLeftCell.isPresent(), is(true));
+        assertThat(upLeftCell.get().getX(), is(0));
+        assertThat(upLeftCell.get().getY(), is(0));
+
+        assertThat(grid.getUpLeft(grid.get(0, 0)).isPresent(), is(false));
+        assertThat(grid.getUpLeft(grid.get(0, GRID_SIZE-1)).isPresent(), is(false));
+        assertThat(grid.getUpLeft(grid.get(GRID_SIZE-1, 0)).isPresent(), is(false));
+        assertThat(grid.getUpLeft(grid.get(GRID_SIZE-1, GRID_SIZE-1)).isPresent(), is(true));
+
+        // down right Cell
+        Optional<MockCell> downRightCell = grid.getDownRight(grid.get(1, 1));
+
+        assertThat(downRightCell.isPresent(), is(true));
+        assertThat(downRightCell.get().getX(), is(2));
+        assertThat(downRightCell.get().getY(), is(2));
+
+        assertThat(grid.getDownRight(grid.get(0, 0)).isPresent(), is(true));
+        assertThat(grid.getDownRight(grid.get(0, GRID_SIZE-1)).isPresent(), is(false));
+        assertThat(grid.getDownRight(grid.get(GRID_SIZE-1, 0)).isPresent(), is(false));
+        assertThat(grid.getDownRight(grid.get(GRID_SIZE-1, GRID_SIZE-1)).isPresent(), is(false));
+
+        // down left cell
+        Optional<MockCell> downLeftCell = grid.getDownLeft(grid.get(1, 1));
+
+        assertThat(downLeftCell.isPresent(), is(true));
+        assertThat(downLeftCell.get().getX(), is(0));
+        assertThat(downLeftCell.get().getY(), is(2));
+
+        assertThat(grid.getDownLeft(grid.get(0, 0)).isPresent(), is(false));
+        assertThat(grid.getDownLeft(grid.get(0, GRID_SIZE-1)).isPresent(), is(false));
+        assertThat(grid.getDownLeft(grid.get(GRID_SIZE-1, 0)).isPresent(), is(true));
+        assertThat(grid.getDownLeft(grid.get(GRID_SIZE-1, GRID_SIZE-1)).isPresent(), is(false));
+    }
+
     public static class MockCell extends Cell {
 
         public MockCell(int x, int y) {

--- a/fxgl-entity/src/main/java/com/almasb/fxgl/pathfinding/astar/AStarGrid.java
+++ b/fxgl-entity/src/main/java/com/almasb/fxgl/pathfinding/astar/AStarGrid.java
@@ -6,6 +6,7 @@
 
 package com.almasb.fxgl.pathfinding.astar;
 
+import com.almasb.fxgl.core.collection.grid.Diagonal;
 import com.almasb.fxgl.core.collection.grid.Grid;
 import com.almasb.fxgl.entity.Entity;
 import com.almasb.fxgl.entity.GameWorld;
@@ -27,6 +28,10 @@ public class AStarGrid extends Grid<AStarCell> {
      */
     public AStarGrid(int width, int height) {
         super(AStarCell.class, width, height, (x, y) -> new AStarCell(x, y, CellState.WALKABLE));
+    }
+
+    public AStarGrid(int width, int height, Diagonal diagonals) {
+        super(AStarCell.class, width, height, diagonals, (x, y) -> new AStarCell(x, y, CellState.WALKABLE));
     }
 
     public List<AStarCell> getWalkableCells() {

--- a/fxgl-entity/src/test/java/com/almasb/fxgl/pathfinding/astar/AStarGridTest.java
+++ b/fxgl-entity/src/test/java/com/almasb/fxgl/pathfinding/astar/AStarGridTest.java
@@ -6,6 +6,7 @@
 
 package com.almasb.fxgl.pathfinding.astar;
 
+import com.almasb.fxgl.core.collection.grid.Diagonal;
 import com.almasb.fxgl.entity.Entity;
 import com.almasb.fxgl.entity.GameWorld;
 import com.almasb.fxgl.pathfinding.CellState;
@@ -44,6 +45,17 @@ public class AStarGridTest {
                 assertFalse(grid.get(x, y).getState().isNotWalkable());
             }
         }
+    }
+
+    @Test
+    public void testDiagonalAssignment() {
+        assertEquals(Diagonal.NEVER, grid.getDiagonal());
+
+        grid.setDiagonal(Diagonal.ALLOWED);
+        assertEquals(Diagonal.ALLOWED, grid.getDiagonal());
+
+        grid = new AStarGrid(GRID_SIZE, GRID_SIZE, Diagonal.ALLOWED);
+        assertEquals(Diagonal.ALLOWED, grid.getDiagonal());
     }
 
     @Test

--- a/fxgl-entity/src/test/kotlin/com/almasb/fxgl/pathfinding/astar/AStarPathfinderTest.kt
+++ b/fxgl-entity/src/test/kotlin/com/almasb/fxgl/pathfinding/astar/AStarPathfinderTest.kt
@@ -5,6 +5,7 @@
  */
 package com.almasb.fxgl.pathfinding.astar
 
+import com.almasb.fxgl.core.collection.grid.Diagonal
 import com.almasb.fxgl.pathfinding.CellState
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.`is`
@@ -46,6 +47,21 @@ class AStarPathfinderTest {
                 5, 1,
                 5, 0)
 
+        // Now test Diagonal Path Finding
+        grid.diagonal = Diagonal.ALLOWED
+        path = pathfinder.findPath(3, 0, 5, 0)
+        assertPathEquals(path,
+                3, 1,
+                3, 2,
+                3, 3,
+                3, 4,
+                4, 5,
+                5, 4,
+                5, 3,
+                5, 2,
+                5, 1,
+                5, 0)
+
         // Make passing impossible.
         for (i in 0..19) grid[4, i].state = CellState.NOT_WALKABLE
         path = pathfinder.findPath(3, 0, 5, 0)
@@ -60,7 +76,7 @@ class AStarPathfinderTest {
         grid[3, 3].state = CellState.NOT_WALKABLE
         grid[3, 5].state = CellState.NOT_WALKABLE
         grid[1, 4].state = CellState.NOT_WALKABLE
-        val path = pathfinder.findPath(1, 1, 4, 5, ArrayList())
+        var path = pathfinder.findPath(1, 1, 4, 5, ArrayList())
 
         assertThat(path.size, `is`(7))
 
@@ -69,9 +85,30 @@ class AStarPathfinderTest {
         assertThat(last.x, `is`(4))
         assertThat(last.y, `is`(5))
 
-        val pathWithBusyCell = pathfinder.findPath(1, 1, 4, 5, listOf(grid[3, 4]))
+        var pathWithBusyCell = pathfinder.findPath(1, 1, 4, 5, listOf(grid[3, 4]))
 
         assertThat(pathWithBusyCell.size, `is`(9))
+
+        last = pathWithBusyCell.last()
+
+        assertThat(last.x, `is`(4))
+        assertThat(last.y, `is`(5))
+
+        // Perform Diagonal Testing
+        grid.diagonal = Diagonal.ALLOWED
+
+        path = pathfinder.findPath(1, 1, 4, 5, ArrayList())
+
+        assertThat(path.size, `is`(4))
+
+        last = path.last()
+
+        assertThat(last.x, `is`(4))
+        assertThat(last.y, `is`(5))
+
+        pathWithBusyCell = pathfinder.findPath(1, 1, 4, 5, listOf(grid[3, 4]))
+
+        assertThat(pathWithBusyCell.size, `is`(6))
 
         last = pathWithBusyCell.last()
 

--- a/fxgl-samples/src/main/java/intermediate/ai/pathfinding/AStarPathfindingSample.java
+++ b/fxgl-samples/src/main/java/intermediate/ai/pathfinding/AStarPathfindingSample.java
@@ -8,6 +8,7 @@ package intermediate.ai.pathfinding;
 
 import com.almasb.fxgl.app.GameApplication;
 import com.almasb.fxgl.app.GameSettings;
+import com.almasb.fxgl.core.collection.grid.Diagonal;
 import com.almasb.fxgl.entity.Entity;
 import com.almasb.fxgl.pathfinding.CellMoveComponent;
 import com.almasb.fxgl.pathfinding.CellState;
@@ -40,7 +41,7 @@ public class AStarPathfindingSample extends GameApplication {
 
     @Override
     protected void initGame() {
-        var grid = new AStarGrid(1280 / 40, 720 / 40);
+        var grid = new AStarGrid(1280 / 40, 720 / 40, Diagonal.ALLOWED);
 
         agent = entityBuilder()
                 .viewWithBBox(new Rectangle(40, 40, Color.BLUE))


### PR DESCRIPTION
Hi @AlmasB ,

I've completed the implementation to allow diagonal Pathfinding movement. This implementation is "backward compatible" by setting the parameter Diagonal to "Never" by default. To enable Diagonal movement, simply provide the Diagonal.ALLOWED flag in the constructor or through it's Setter.

I've defaulted the AStarPathfindingSample to Diagonal.ALLOWED.

As requested, I'll do the changes "step by step".
Note: Because I'm doing it "step by step", this means that future PRs will depend on each others.

Possible Upcoming changes (No promises):
- Optimizations -> Reduced memory allocation, Faster calculation, etc
- Include a "No Corner Crossing" option -> This is to prevent "noisy" collisions detection when an Entity walks close to a diagonal wall
- Flexible CellState definition -> Ability to define your own CellStates & allow defining "allowed" states while retrieving the Path. For example, you could wish to have a single state grid that will support Ground vs Water vs Amphibious pathfinding
- Allow AStarGrid (.fromWorld(...)) to be loaded by Entity instead of restricting it by entity types. Currently, only the type of the entity may be used to define if a Cell is walkable or not. Having the Entity directly offers more flexibility.
- 16 Directions Pathfinding -> Tricky, but it would add a noticeable "smoothness" to Entity movements

Let me know if I should adjust it.