### PR TITLE
fix: bind fullscreen button text to localization service

### DIFF
--- a/fxgl-samples/src/main/java/tutorial/BreakoutApp.java
+++ b/fxgl-samples/src/main/java/tutorial/BreakoutApp.java
@@ -17,7 +17,6 @@ import com.almasb.fxgl.input.UserAction;
 import javafx.geometry.Point2D;
 import javafx.scene.input.KeyCode;
 import javafx.scene.paint.Color;
-import javafx.scene.shape.Circle;
 import javafx.scene.shape.Rectangle;
 
 import static com.almasb.fxgl.dsl.FXGL.*;
@@ -42,14 +41,7 @@ public class BreakoutApp extends GameApplication {
 
     @Override
     protected void initSettings(GameSettings settings) {
-        settings.setWidth(800);
-        settings.setHeight(600);
-        settings.setTitle("Breakout by shimon, reproduce bug ");
-        settings.setMainMenuEnabled(true);
-        settings.setGameMenuEnabled(true);
-        settings.setFullScreenAllowed(true);
-
-
+        settings.setTitle("Breakout");
     }
 
     @Override
@@ -172,7 +164,7 @@ public class BreakoutApp extends GameApplication {
             return entityBuilder()
                     .from(data)
                     .type(BreakoutType.BALL)
-                    .viewWithBBox(new Circle(BALL_SIZE,  Color.BLACK))
+                    .viewWithBBox(new Rectangle(BALL_SIZE, BALL_SIZE, Color.BLUE))
                     .collidable()
                     .with("velocity", new Point2D(BALL_SPEED, BALL_SPEED))
                     .build();
@@ -188,7 +180,6 @@ public class BreakoutApp extends GameApplication {
                     .build();
         }
     }
-
 
     public static void main(String[] args) {
         launch(args);

--- a/fxgl-samples/src/main/java/tutorial/BreakoutApp.java
+++ b/fxgl-samples/src/main/java/tutorial/BreakoutApp.java
@@ -17,6 +17,7 @@ import com.almasb.fxgl.input.UserAction;
 import javafx.geometry.Point2D;
 import javafx.scene.input.KeyCode;
 import javafx.scene.paint.Color;
+import javafx.scene.shape.Circle;
 import javafx.scene.shape.Rectangle;
 
 import static com.almasb.fxgl.dsl.FXGL.*;
@@ -41,7 +42,14 @@ public class BreakoutApp extends GameApplication {
 
     @Override
     protected void initSettings(GameSettings settings) {
-        settings.setTitle("Breakout");
+        settings.setWidth(800);
+        settings.setHeight(600);
+        settings.setTitle("Breakout by shimon, reproduce bug ");
+        settings.setMainMenuEnabled(true);
+        settings.setGameMenuEnabled(true);
+        settings.setFullScreenAllowed(true);
+
+
     }
 
     @Override
@@ -164,7 +172,7 @@ public class BreakoutApp extends GameApplication {
             return entityBuilder()
                     .from(data)
                     .type(BreakoutType.BALL)
-                    .viewWithBBox(new Rectangle(BALL_SIZE, BALL_SIZE, Color.BLUE))
+                    .viewWithBBox(new Circle(BALL_SIZE,  Color.BLACK))
                     .collidable()
                     .with("velocity", new Point2D(BALL_SPEED, BALL_SPEED))
                     .build();
@@ -180,6 +188,7 @@ public class BreakoutApp extends GameApplication {
                     .build();
         }
     }
+
 
     public static void main(String[] args) {
         launch(args);

--- a/fxgl/src/main/kotlin/com/almasb/fxgl/app/scene/FXGLDefaultMenu.kt
+++ b/fxgl/src/main/kotlin/com/almasb/fxgl/app/scene/FXGLDefaultMenu.kt
@@ -681,7 +681,7 @@ open class FXGLDefaultMenu(type: MenuType) : FXGLMenu(type) {
             val cbFullScreen = getUIFactoryService().newCheckBox()
             cbFullScreen.selectedProperty().bindBidirectional(getSettings().fullScreen)
 
-            vbox.children.add(HBox(25.0, getUIFactoryService().newText(localize("menu.fullscreen") + ": "), cbFullScreen))
+            vbox.children.add(HBox(25.0, getUIFactoryService().newText(localizedStringProperty("menu.fullscreen").concat(": ")), cbFullScreen))
         }
 
         return MenuContent(


### PR DESCRIPTION
The fullscreen button text was set only once during initialization.
Changed it to bind to the localization property so it updates dynamically when language changes.
(Followed the suggested fix)