### PR TITLE
fix: recycle particle instead of emitter position back to pool in ParticleSystem

### DIFF
--- a/fxgl-core/src/main/kotlin/com/almasb/fxgl/particle/ParticleSystem.kt
+++ b/fxgl-core/src/main/kotlin/com/almasb/fxgl/particle/ParticleSystem.kt
@@ -48,7 +48,7 @@ class ParticleSystem : Updatable {
                     iter.remove()
 
                     pane.children.remove(particle.view)
-                    Pools.free(p)
+                    Pools.free(particle)
                 } else {
                     if (particle.view.parent == null)
                         pane.children.add(particle.view)


### PR DESCRIPTION
Fixes #1417

In `ParticleSystem.onUpdate`, when a particle expires it should be returned to the object pool via `Pools.free(particle)`. Instead, `Pools.free(p)` was being called, which freed the emitter's `Point2D` position — a completely different object.

Changed `Pools.free(p)` → `Pools.free(particle)` on the removal path.