### PR TITLE
feat: allow selecting difficulty in the gameplay menu

### DIFF
--- a/fxgl-samples/src/main/java/intermediate/MenuSample.java
+++ b/fxgl-samples/src/main/java/intermediate/MenuSample.java
@@ -29,7 +29,7 @@ public class MenuSample extends GameApplication {
         settings.setMainMenuEnabled(true);
         settings.setGameMenuEnabled(true);
         settings.setFullScreenAllowed(true);
-        settings.setEnabledMenuItems(EnumSet.of(MenuItem.DIFFICULTY));
+        settings.setEnabledMenuItems(EnumSet.of(MenuItem.DIFFICULTY, MenuItem.EXTRA));
         settings.getCredits().addAll(Arrays.asList(
                 "Short Name - Lead Programmer",
                 "LongLongLongLongLongLongLong Name - Programmer",

--- a/fxgl-samples/src/main/java/intermediate/MenuSample.java
+++ b/fxgl-samples/src/main/java/intermediate/MenuSample.java
@@ -29,7 +29,7 @@ public class MenuSample extends GameApplication {
         settings.setMainMenuEnabled(true);
         settings.setGameMenuEnabled(true);
         settings.setFullScreenAllowed(true);
-        settings.setEnabledMenuItems(EnumSet.of(MenuItem.EXTRA));
+        settings.setEnabledMenuItems(EnumSet.of(MenuItem.DIFFICULTY));
         settings.getCredits().addAll(Arrays.asList(
                 "Short Name - Lead Programmer",
                 "LongLongLongLongLongLongLong Name - Programmer",

--- a/fxgl/src/main/kotlin/com/almasb/fxgl/app/Settings.kt
+++ b/fxgl/src/main/kotlin/com/almasb/fxgl/app/Settings.kt
@@ -60,7 +60,12 @@ enum class MenuItem {
     /**
      * Enables ONLINE (multiplayer).
      */
-    ONLINE
+    ONLINE,
+
+    /**
+     * Enables DIFFICULTY -> EASY, MEDIUM, HARD, CUSTOM
+     */
+    DIFFICULTY,
 }
 
 /**

--- a/fxgl/src/main/kotlin/com/almasb/fxgl/app/Settings.kt
+++ b/fxgl/src/main/kotlin/com/almasb/fxgl/app/Settings.kt
@@ -63,7 +63,7 @@ enum class MenuItem {
     ONLINE,
 
     /**
-     * Enables DIFFICULTY -> EASY, MEDIUM, HARD, CUSTOM
+     * Enables DIFFICULTY -> EASY, MEDIUM, HARD, NIGHTMARE
      */
     DIFFICULTY,
 }

--- a/fxgl/src/main/kotlin/com/almasb/fxgl/app/scene/FXGLDefaultMenu.kt
+++ b/fxgl/src/main/kotlin/com/almasb/fxgl/app/scene/FXGLDefaultMenu.kt
@@ -16,6 +16,7 @@ import com.almasb.fxgl.dsl.*
 import com.almasb.fxgl.dsl.FXGL.Companion.animationBuilder
 import com.almasb.fxgl.dsl.FXGL.Companion.random
 import com.almasb.fxgl.dsl.FXGL.Companion.texture
+import com.almasb.fxgl.gameplay.GameDifficulty
 import com.almasb.fxgl.input.Input
 import com.almasb.fxgl.input.InputModifier
 import com.almasb.fxgl.input.Trigger
@@ -258,6 +259,12 @@ open class FXGLDefaultMenu(type: MenuType) : FXGLMenu(type) {
         itemOptions.setChild(createOptionsMenu())
         box.add(itemOptions)
 
+        if (enabledItems.contains(MenuItem.DIFFICULTY)) {
+            val itemDifficulty = MenuButton("menu.difficulty")
+            itemDifficulty.setMenuContent({ createContentDifficulty() })
+            box.add(itemDifficulty)
+        }
+
         if (enabledItems.contains(MenuItem.EXTRA)) {
             val itemExtra = MenuButton("menu.extra")
             itemExtra.setChild(createExtraMenu())
@@ -314,6 +321,30 @@ open class FXGLDefaultMenu(type: MenuType) : FXGLMenu(type) {
         }
 
         return box
+    }
+
+    private fun createContentDifficulty(): MenuContent {
+        val difficultyBox = getUIFactoryService().newChoiceBox(
+            FXCollections.observableArrayList(GameDifficulty.entries)
+        )
+
+        difficultyBox.styleClass.add("fxgl-difficulty-menu-choicebox")
+
+        difficultyBox.value = getSettings().gameDifficulty
+        getSettings().gameDifficultyProperty().bindBidirectional(difficultyBox.valueProperty())
+
+        difficultyBox.valueProperty().addListener { _, _, _ ->
+            switchMenuContentTo(EMPTY)
+        }
+
+        val row = HBox(
+            25.0,
+            getUIFactoryService().newText(localizedStringProperty("menu.difficulty").concat(":")),
+            difficultyBox
+        )
+        row.alignment = Pos.CENTER
+
+        return MenuContent(row)
     }
 
     private fun createOptionsMenu(): MenuBox {

--- a/fxgl/src/main/kotlin/com/almasb/fxgl/app/scene/FXGLDefaultMenu.kt
+++ b/fxgl/src/main/kotlin/com/almasb/fxgl/app/scene/FXGLDefaultMenu.kt
@@ -261,7 +261,7 @@ open class FXGLDefaultMenu(type: MenuType) : FXGLMenu(type) {
 
         if (enabledItems.contains(MenuItem.DIFFICULTY)) {
             val itemDifficulty = MenuButton("menu.difficulty")
-            itemDifficulty.setMenuContent({ createContentDifficulty() })
+            itemDifficulty.setMenuContent({ createDifficultyMenu() })
             box.add(itemDifficulty)
         }
 
@@ -304,6 +304,12 @@ open class FXGLDefaultMenu(type: MenuType) : FXGLMenu(type) {
         itemOptions.setChild(createOptionsMenu())
         box.add(itemOptions)
 
+        if (enabledItems.contains(MenuItem.DIFFICULTY)) {
+            val itemDifficulty = MenuButton("menu.difficulty")
+            itemDifficulty.setMenuContent({ createDifficultyMenu() })
+            box.add(itemDifficulty)
+        }
+
         if (enabledItems.contains(MenuItem.EXTRA)) {
             val itemExtra = MenuButton("menu.extra")
             itemExtra.setChild(createExtraMenu())
@@ -321,30 +327,6 @@ open class FXGLDefaultMenu(type: MenuType) : FXGLMenu(type) {
         }
 
         return box
-    }
-
-    private fun createContentDifficulty(): MenuContent {
-        val difficultyBox = getUIFactoryService().newChoiceBox(
-            FXCollections.observableArrayList(GameDifficulty.entries)
-        )
-
-        difficultyBox.styleClass.add("fxgl-difficulty-menu-choicebox")
-
-        difficultyBox.value = getSettings().gameDifficulty
-        getSettings().gameDifficultyProperty().bindBidirectional(difficultyBox.valueProperty())
-
-        difficultyBox.valueProperty().addListener { _, _, _ ->
-            switchMenuContentTo(EMPTY)
-        }
-
-        val row = HBox(
-            25.0,
-            getUIFactoryService().newText(localizedStringProperty("menu.difficulty").concat(":")),
-            difficultyBox
-        )
-        row.alignment = Pos.CENTER
-
-        return MenuContent(row)
     }
 
     private fun createOptionsMenu(): MenuBox {
@@ -372,6 +354,30 @@ open class FXGLDefaultMenu(type: MenuType) : FXGLMenu(type) {
         }
 
         return MenuBox(itemGameplay, itemControls, itemVideo, itemAudio, btnRestore)
+    }
+
+    private fun createDifficultyMenu(): MenuContent {
+        val difficultyBox = getUIFactoryService().newChoiceBox(
+            FXCollections.observableArrayList(GameDifficulty.entries)
+        )
+
+        difficultyBox.styleClass.add("fxgl-difficulty-choice-box")
+
+        difficultyBox.value = getSettings().gameDifficulty
+        getSettings().gameDifficultyProperty().bindBidirectional(difficultyBox.valueProperty())
+
+        difficultyBox.valueProperty().addListener { _, _, _ ->
+            switchMenuContentTo(EMPTY)
+        }
+
+        val row = HBox(
+            25.0,
+            getUIFactoryService().newText(localizedStringProperty("menu.difficulty").concat(":")),
+            difficultyBox
+        )
+        row.alignment = Pos.CENTER
+
+        return MenuContent(row)
     }
 
     private fun createExtraMenu(): MenuBox {

--- a/fxgl/src/main/resources/fxglassets/ui/css/fxgl_dark.css
+++ b/fxgl/src/main/resources/fxglassets/ui/css/fxgl_dark.css
@@ -312,7 +312,7 @@
 /*
  * Styling for the difficulty choice box
  */
-.fxgl-difficulty-menu-choicebox {
+.fxgl-difficulty-choice-box {
     -fx-background-color: rgba(0, 0, 0, 0.35);
     -fx-background-radius: 4;
     -fx-background-insets: 0;
@@ -321,26 +321,26 @@
     -fx-font-size: 18px;
 }
 
-.fxgl-difficulty-menu-choicebox:hover,
-.fxgl-difficulty-menu-choicebox:focused,
-.fxgl-difficulty-menu-choicebox:focused:hover,
-.fxgl-difficulty-menu-choicebox:armed {
+.fxgl-difficulty-choice-box:hover,
+.fxgl-difficulty-choice-box:focused,
+.fxgl-difficulty-choice-box:focused:hover,
+.fxgl-difficulty-choice-box:armed {
     -fx-background-color: rgba(0, 0, 0, 0.45);
     -fx-background-radius: 4;
     -fx-background-insets: 0;
     -fx-border-color: rgba(255, 255, 255, 0.35);
 }
 
-.fxgl-difficulty-menu-choicebox .label {
+.fxgl-difficulty-choice-box .label {
     -fx-text-fill: white;
     -fx-background-color: transparent;
 }
 
-.fxgl-difficulty-menu-choicebox .context-menu {
+.fxgl-difficulty-choice-box .context-menu {
     -fx-background-color: rgba(20, 20, 20, 0.9);
 }
 
-.fxgl-difficulty-menu-choicebox .menu-item:focused {
+.fxgl-difficulty-choice-box .menu-item:focused {
     -fx-background-color: rgba(255, 255, 255, 0.15);
 }
 

--- a/fxgl/src/main/resources/fxglassets/ui/css/fxgl_dark.css
+++ b/fxgl/src/main/resources/fxglassets/ui/css/fxgl_dark.css
@@ -309,6 +309,40 @@
 }
 
 
+/*
+ * Styling for the difficulty choice box
+ */
+.fxgl-difficulty-menu-choicebox {
+    -fx-background-color: rgba(0, 0, 0, 0.35);
+    -fx-background-radius: 4;
+    -fx-background-insets: 0;
+    -fx-border-color: rgba(255, 255, 255, 0.25);
+    -fx-border-radius: 4;
+    -fx-font-size: 18px;
+}
+
+.fxgl-difficulty-menu-choicebox:hover,
+.fxgl-difficulty-menu-choicebox:focused,
+.fxgl-difficulty-menu-choicebox:focused:hover,
+.fxgl-difficulty-menu-choicebox:armed {
+    -fx-background-color: rgba(0, 0, 0, 0.45);
+    -fx-background-radius: 4;
+    -fx-background-insets: 0;
+    -fx-border-color: rgba(255, 255, 255, 0.35);
+}
+
+.fxgl-difficulty-menu-choicebox .label {
+    -fx-text-fill: white;
+    -fx-background-color: transparent;
+}
+
+.fxgl-difficulty-menu-choicebox .context-menu {
+    -fx-background-color: rgba(20, 20, 20, 0.9);
+}
+
+.fxgl-difficulty-menu-choicebox .menu-item:focused {
+    -fx-background-color: rgba(255, 255, 255, 0.15);
+}
 
 
 /*


### PR DESCRIPTION
Closes #1449

New menu for selecting difficulty in both the main menu and the in-game menu.
Added specific CSS styling to fix the issue of the difficulty choice-box not accepting the general style.
Updated `MenuSample.java` to showcase the new difficulty menu.
Uses existing `gameDifficultyProperty` from the `ReadOnlyGameSettings` class in `settings.kt`.
