### PR TITLE
Add rotation support to WaypointMoveComponent

### DIFF
--- a/fxgl-samples/src/main/kotlin/sandbox/components/WaypointMoveComponentSample.kt
+++ b/fxgl-samples/src/main/kotlin/sandbox/components/WaypointMoveComponentSample.kt
@@ -1,0 +1,71 @@
+/*
+ * FXGL - JavaFX Game Library. The MIT License (MIT).
+ * Copyright (c) AlmasB (almaslvl@gmail.com).
+ * See LICENSE for details.
+ */
+
+package sandbox.components
+
+import com.almasb.fxgl.app.GameApplication
+import com.almasb.fxgl.app.GameSettings
+import com.almasb.fxgl.dsl.*
+import com.almasb.fxgl.dsl.components.WaypointMoveComponent
+import javafx.geometry.Point2D
+import javafx.scene.paint.Color
+import javafx.scene.shape.Circle
+import javafx.scene.shape.Polygon
+
+/**
+ * Sample showing WaypointMoveComponent with rotation enabled.
+ *
+ * The arrow-shaped entity moves between several waypoints and rotates
+ * towards the next waypoint as it changes direction.
+ */
+class WaypointMoveComponentSample : GameApplication() {
+
+    override fun initSettings(settings: GameSettings) {
+        settings.width = 800
+        settings.height = 600
+        settings.title = "WaypointMoveComponent Sample"
+    }
+
+    override fun initGame() {
+        getGameScene().setBackgroundColor(Color.BLACK)
+
+        val waypoints = listOf(
+                Point2D(100.0, 100.0),
+                Point2D(650.0, 100.0),
+                Point2D(650.0, 450.0),
+                Point2D(100.0, 450.0),
+                Point2D(100.0, 100.0)
+        )
+
+        // Draw waypoint markers so the movement path is visible.
+        waypoints.forEach { point ->
+            entityBuilder()
+                    .at(point.x, point.y)
+                    .view(Circle(6.0, Color.RED))
+                    .buildAndAttach()
+        }
+
+        // Arrow shape pointing right, so rotation is clearly visible.
+        val arrow = Polygon(
+                0.0, 0.0,
+                50.0, 20.0,
+                0.0, 40.0
+        ).apply {
+            fill = Color.BLUE
+            stroke = Color.WHITE
+        }
+
+        entityBuilder()
+                .at(100.0, 100.0)
+                .view(arrow)
+                .with(WaypointMoveComponent(150.0, waypoints).allowRotation(true))
+                .buildAndAttach()
+    }
+}
+
+fun main(args: Array<String>) {
+    GameApplication.launch(WaypointMoveComponentSample::class.java, args)
+}

--- a/fxgl/src/main/kotlin/com/almasb/fxgl/dsl/components/WaypointMoveComponent.kt
+++ b/fxgl/src/main/kotlin/com/almasb/fxgl/dsl/components/WaypointMoveComponent.kt
@@ -19,7 +19,8 @@ import javafx.geometry.Point2D
  */
 class WaypointMoveComponent(
         var speed: Double,
-        waypoints: List<Point2D>) : Component() {
+        waypoints: List<Point2D>
+) : Component() {
 
     private val log = Logger.get<WaypointMoveComponent>()
 
@@ -28,11 +29,21 @@ class WaypointMoveComponent(
 
     private val isAtDestinationProp = ReadOnlyBooleanWrapper(true)
 
+    private var isAllowRotation = false
+
     init {
         move(waypoints)
     }
 
     fun atDestinationProperty(): ReadOnlyBooleanProperty = isAtDestinationProp.readOnlyProperty
+
+    /**
+     * Allows enabling or disabling rotation towards the current movement direction.
+     */
+    fun allowRotation(allowRotation: Boolean): WaypointMoveComponent {
+        isAllowRotation = allowRotation
+        return this
+    }
 
     fun move(waypoints: List<Point2D>) {
         points.clear()
@@ -48,22 +59,39 @@ class WaypointMoveComponent(
         isAtDestinationProp.value = false
     }
 
+    override fun onAdded() {
+        updateRotation()
+    }
+
     override fun onUpdate(tpf: Double) {
         if (isAtDestinationProp.value)
             return
 
         val dist = tpf * speed
 
-        if (nextPoint.distance(entity.anchoredPosition) < dist) {
+        if (nextPoint.distance(entity.anchoredPosition) <= dist) {
             entity.anchoredPosition = nextPoint
 
             if (points.isNotEmpty()) {
                 nextPoint = points.removeAt(0)
+                updateRotation()
             } else {
                 isAtDestinationProp.value = true
             }
         } else {
+            updateRotation()
             entity.translateTowards(nextPoint, dist)
+        }
+    }
+
+    private fun updateRotation() {
+        if (!isAllowRotation)
+            return
+
+        val movementVector = nextPoint.subtract(entity.anchoredPosition)
+
+        if (movementVector.magnitude() > 0.0) {
+            entity.rotateToVector(movementVector)
         }
     }
 


### PR DESCRIPTION
This PR adds optional rotation support to `WaypointMoveComponent`.

Changes made:
- Added `allowRotation(boolean)` to enable or disable rotation towards the current waypoint.
- Rotation is calculated using the vector from the entity’s current anchored position to the next waypoint.
- Added a new `fxgl-samples` example showing an arrow-shaped entity moving between waypoints with rotation enabled.

This addresses the remaining part of issue #980.