### PR TITLE
feat: #1224 framework wide UI font scaling and per area scale override

### DIFF
--- a/fxgl-scene/src/main/kotlin/com/almasb/fxgl/notification/impl/NotificationServiceProvider.kt
+++ b/fxgl-scene/src/main/kotlin/com/almasb/fxgl/notification/impl/NotificationServiceProvider.kt
@@ -49,10 +49,17 @@ class NotificationServiceProvider : NotificationService() {
     @Inject("notificationViewClass")
     private lateinit var notificationViewClass: Class<out NotificationView>
 
+    @Inject("fontSizeScaleUI")
+    private var fontSizeScaleUI = 1.0
+
+    @Inject("fontSizeScaleNotification")
+    private var fontSizeScaleNotification = 1.0
+
     private val notificationView by lazy {
         ReflectionUtils.newInstance(notificationViewClass).also {
             it.appWidth = sceneService.prefWidth.toInt()
             it.appHeight = sceneService.prefHeight.toInt()
+            it.fontSize = fontSizeScaleUI * fontSizeScaleNotification * 18.0
         }
     }
 

--- a/fxgl-scene/src/main/kotlin/com/almasb/fxgl/notification/view/NotificationView.kt
+++ b/fxgl-scene/src/main/kotlin/com/almasb/fxgl/notification/view/NotificationView.kt
@@ -25,6 +25,7 @@ abstract class NotificationView : Pane(), Updatable {
     // these will be updated during notification service init
     var appWidth = 800
     var appHeight = 600
+    var fontSize = 18.0
 
     /**
      * Called when view is added to scene.

--- a/fxgl-scene/src/main/kotlin/com/almasb/fxgl/notification/view/XboxNotificationView.kt
+++ b/fxgl-scene/src/main/kotlin/com/almasb/fxgl/notification/view/XboxNotificationView.kt
@@ -40,12 +40,10 @@ class XboxNotificationView : NotificationView() {
      */
     private val text1 = Text().also {
         it.fill = textColor
-        it.font = Font.font(18.0)
     }
 
     private val text2 = Text().also {
         it.fill = textColor
-        it.font = Font.font(18.0)
     }
 
     init {
@@ -67,9 +65,11 @@ class XboxNotificationView : NotificationView() {
         text1.translateY = 35.0
         text1.isVisible = false
         text1.fill = textColor
+        text1.font = Font.font(fontSize)
         text1.text = ""
 
         text2.fill = textColor
+        text2.font = Font.font(fontSize)
 
         translateX = appWidth / 2 - bg.width / 2 + 200
         translateY = 50.0

--- a/fxgl-scene/src/main/kotlin/com/almasb/fxgl/ui/FXGLDialogFactoryServiceProvider.kt
+++ b/fxgl-scene/src/main/kotlin/com/almasb/fxgl/ui/FXGLDialogFactoryServiceProvider.kt
@@ -36,8 +36,8 @@ import java.util.function.Predicate
  */
 class FXGLDialogFactoryServiceProvider : DialogFactoryService() {
 
-    @Inject("fontSizeScaleUI")
-    private var fontSizeScaleUI = 1.0
+    @Inject("fontSizeScaleDialog")
+    private var fontSizeScaleDialog = 1.0
 
     private lateinit var uiFactory: UIFactoryService
 
@@ -155,7 +155,7 @@ class FXGLDialogFactoryServiceProvider : DialogFactoryService() {
 
         val field = TextField()
         field.maxWidth = Math.max(text.layoutBounds.width, 200.0)
-        field.font = uiFactory.newFont(18.0)
+        field.font = uiFactory.newFont(fontSizeScaleDialog * 18.0)
 
         field.focusedProperty().addListener { _, _, isFocused ->
             if (!isFocused && field.scene != null) {
@@ -200,7 +200,7 @@ class FXGLDialogFactoryServiceProvider : DialogFactoryService() {
 
         val field = TextField()
         field.maxWidth = Math.max(text.layoutBounds.width, 200.0)
-        field.font = uiFactory.newFont(18.0)
+        field.font = uiFactory.newFont(fontSizeScaleDialog * 18.0)
 
         val btnOK = uiFactory.newButton(localizedStringProperty("dialog.ok"))
 
@@ -302,7 +302,7 @@ class FXGLDialogFactoryServiceProvider : DialogFactoryService() {
     }
 
     private fun createMessage(message: String): Text {
-        return uiFactory.newText(message, fontSizeScaleUI * 18.0)
+        return uiFactory.newText(message, fontSizeScaleDialog * 18.0)
     }
 
     private fun localizedStringProperty(key: String): StringBinding {

--- a/fxgl-scene/src/main/kotlin/com/almasb/fxgl/ui/FXGLUIFactoryServiceProvider.kt
+++ b/fxgl-scene/src/main/kotlin/com/almasb/fxgl/ui/FXGLUIFactoryServiceProvider.kt
@@ -6,6 +6,7 @@
 
 package com.almasb.fxgl.ui
 
+import com.almasb.fxgl.core.Inject
 import com.almasb.fxgl.core.collection.PropertyMap
 import com.almasb.fxgl.core.math.Vec2
 import com.almasb.fxgl.logging.Logger
@@ -34,6 +35,9 @@ import java.util.concurrent.Callable
 class FXGLUIFactoryServiceProvider : UIFactoryService() {
 
     private val log = Logger.get(javaClass)
+
+    @Inject("fontSizeScaleUI")
+    private var fontSizeScaleUI = 1.0
 
     private val fontFactories = hashMapOf<FontType, ObjectProperty<FontFactory>>()
     private val propertyViewFactories = hashMapOf<Class<*>, PropertyViewFactory<*, *>>()
@@ -90,7 +94,7 @@ class FXGLUIFactoryServiceProvider : UIFactoryService() {
     }
 
     override fun newFont(type: FontType, size: Double): Font {
-        val font = fontFactories[type]?.value?.newFont(size)
+        val font = fontFactories[type]?.value?.newFont(fontSizeScaleUI * size)
 
         if (font != null) {
             return font
@@ -98,7 +102,7 @@ class FXGLUIFactoryServiceProvider : UIFactoryService() {
 
         log.warning("No font factory found for $type. Using default")
 
-        return Font.font(size)
+        return Font.font(fontSizeScaleUI * size)
     }
     
     override fun newButton(text: String): Button {
@@ -205,6 +209,6 @@ class FXGLUIFactoryServiceProvider : UIFactoryService() {
 
     private fun fontProperty(type: FontType, fontSize: Double) =
             Bindings.createObjectBinding(Callable {
-                return@Callable fontFactories[type]!!.value.newFont(fontSize)
+                return@Callable fontFactories[type]!!.value.newFont(fontSizeScaleUI * fontSize)
             }, fontFactories[type]!!)
 }

--- a/fxgl/src/main/kotlin/com/almasb/fxgl/app/Settings.kt
+++ b/fxgl/src/main/kotlin/com/almasb/fxgl/app/Settings.kt
@@ -249,8 +249,24 @@ class GameSettings(
 
         /**
          * Set the scale value for UI text size, default = 1.0.
+         * Applied globally to all text constructed via UIFactoryService.
          */
         var fontSizeScaleUI: Double = 1.0,
+
+        /**
+         * Per-area scale for menu text, multiplied on top of [fontSizeScaleUI], default = 1.0.
+         */
+        var fontSizeScaleMenu: Double = 1.0,
+
+        /**
+         * Per-area scale for dialog text, multiplied on top of [fontSizeScaleUI], default = 1.0.
+         */
+        var fontSizeScaleDialog: Double = 1.0,
+
+        /**
+         * Per-area scale for notification text, multiplied on top of [fontSizeScaleUI], default = 1.0.
+         */
+        var fontSizeScaleNotification: Double = 1.0,
 
         var pixelsPerMeter: Double = 50.0,
 
@@ -409,6 +425,9 @@ class GameSettings(
                 soundMenuPress,
                 soundMenuSelect,
                 fontSizeScaleUI,
+                fontSizeScaleMenu,
+                fontSizeScaleDialog,
+                fontSizeScaleNotification,
                 pixelsPerMeter,
                 collisionDetectionStrategy,
                 secondsIn24h,
@@ -582,6 +601,12 @@ class ReadOnlyGameSettings internal constructor(
         val soundMenuSelect: String,
 
         val fontSizeScaleUI: Double,
+
+        val fontSizeScaleMenu: Double,
+
+        val fontSizeScaleDialog: Double,
+
+        val fontSizeScaleNotification: Double,
 
         val pixelsPerMeter: Double,
 

--- a/fxgl/src/main/kotlin/com/almasb/fxgl/app/scene/FXGLDefaultMenu.kt
+++ b/fxgl/src/main/kotlin/com/almasb/fxgl/app/scene/FXGLDefaultMenu.kt
@@ -69,6 +69,9 @@ open class FXGLDefaultMenu(type: MenuType) : FXGLMenu(type) {
 
     private val particleSystem = ParticleSystem()
 
+    private val menuScale: Double
+        get() = getSettings().fontSizeScaleMenu
+
     private val titleColor = SimpleObjectProperty(Color.WHITE)
     private var t = 0.0
 
@@ -189,12 +192,12 @@ open class FXGLDefaultMenu(type: MenuType) : FXGLMenu(type) {
     }
 
     private fun createTitleView(title: String): Node {
-        val text = getUIFactoryService().newText(title.substring(0, 1), 50.0)
+        val text = getUIFactoryService().newText(title.substring(0, 1), menuScale * 50.0)
         text.fill = null
         text.strokeProperty().bind(titleColor)
         text.strokeWidth = 1.5
 
-        val text2 = getUIFactoryService().newText(title.substring(1, title.length), 50.0)
+        val text2 = getUIFactoryService().newText(title.substring(1, title.length), menuScale * 50.0)
         text2.fill = null
         text2.stroke = titleColor.value
         text2.strokeWidth = 1.5
@@ -540,7 +543,7 @@ open class FXGLDefaultMenu(type: MenuType) : FXGLMenu(type) {
 
                         val nameDate = "%-25.25s %s".format(item.name, item.dateTime.format(DateTimeFormatter.ofPattern("dd-MM-yyyy HH-mm")))
 
-                        val text = getUIFactoryService().newText(nameDate, Color.WHITE, FontType.MONO, FONT_SIZE)
+                        val text = getUIFactoryService().newText(nameDate, Color.WHITE, FontType.MONO, menuScale * FONT_SIZE)
 
                         graphic = text
                     }
@@ -654,7 +657,7 @@ open class FXGLDefaultMenu(type: MenuType) : FXGLMenu(type) {
             rect.arcWidth = 15.0
             rect.arcHeight = 15.0
 
-            val text = getUIFactoryService().newText("", 24.0)
+            val text = getUIFactoryService().newText("", menuScale * 24.0)
             text.textProperty().bind(localizedStringProperty("menu.pressAnyKey"))
 
             val pane = StackPane(rect, text)
@@ -666,7 +669,7 @@ open class FXGLDefaultMenu(type: MenuType) : FXGLMenu(type) {
     }
 
     private fun addNewInputBinding(action: UserAction, trigger: Trigger, grid: GridPane) {
-        val actionName = getUIFactoryService().newText(action.name, Color.WHITE, 18.0)
+        val actionName = getUIFactoryService().newText(action.name, Color.WHITE, menuScale * 18.0)
 
         val triggerView = TriggerView(trigger)
         triggerView.triggerProperty().bind(getInput().triggerProperty(action))


### PR DESCRIPTION
## Description

Resolves the small-text concern raised in discussion #1224 . Made the existing `fontSizeScaleUI` setting actually framework-wide, and introduced three optional per-area scales on top so menus, dialogs, and notifications can each be tuned independently without affecting the rest of the UI.

## Changes

- Moved `fontSizeScaleUI` application into `FXGLUIFactoryServiceProvider` at the single font-construction chokepoint, so every piece of UI routed through `getUIFactoryService()` now scales: menus, buttons, mini-games, dev console, inventory, cutscenes, loading screen, plus user code that uses the factory.
- Added three per-area scales to `GameSettings`, each defaulting to `1.0` and multiplied on top of `fontSizeScaleUI`:
  - `fontSizeScaleMenu`
  - `fontSizeScaleDialog`
  - `fontSizeScaleNotification`
- Wired `fontSizeScaleDialog` into `FXGLDialogFactoryServiceProvider`.
- Wired `fontSizeScaleNotification` into `NotificationServiceProvider`, alongside the existing `fontSizeScaleUI` injection, both are applied because the notification view bypasses `UIFactoryService`.
- Added a `fontSize: Double` field to `NotificationView` and switched `XboxNotificationView` from hardcoded `Font.font(18.0)` to `Font.font(fontSize)` inside `playInAnimation()`.
- Added a `menuScale` computed property to `FXGLDefaultMenu` reading `getSettings().fontSizeScaleMenu`.
- KDoc on each new setting documents the layering: `effective_size = raw * fontSizeScaleUI * fontSizeScaleArea`.

Backward-compatible: all new fields default to `1.0`. Existing user code that only touches `fontSizeScaleUI` continues to work; what changes is that `fontSizeScaleUI` now affects more UI than it used to.
