### PR TITLE
Fix #1346: EmbeddedPaneWindow.isFocused returns actual focus state

### DIFF
--- a/fxgl/src/main/kotlin/com/almasb/fxgl/app/MainWindow.kt
+++ b/fxgl/src/main/kotlin/com/almasb/fxgl/app/MainWindow.kt
@@ -529,7 +529,7 @@ internal class EmbeddedPaneWindow(
         get() = fxglPane.localToScene(0.0, 0.0).y
 
     override val isFocused: Boolean
-        get() = true
+        get() = fxglPane.scene?.window?.isFocused ?: false
 
     override val width: Double
         get() = fxglPane.renderWidth


### PR DESCRIPTION
Closes #1346. 
isFocused now reads the actual focused state of the host window
I changed
"    override val isFocused: Boolean
        get() = true"

to
"    override val isFocused: Boolean
        get() = fxglPane.scene?.window?.isFocused ?: false"